### PR TITLE
changed namespace to PHPOpenSourceSaver

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # These are supported funding model platforms
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: seantymon
+patreon: 
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tymon/jwt-auth",
+    "name": "php-open-source-saver/jwt-auth",
     "description": "JSON Web Token Authentication for Laravel and Lumen",
     "keywords": [
         "auth",
@@ -8,10 +8,10 @@
         "jwt",
         "laravel"
     ],
-    "homepage": "https://github.com/tymondesigns/jwt-auth",
+    "homepage": "https://github.com/PHP-Open-Source-Saver/jwt-auth",
     "support": {
-        "issues": "https://github.com/tymondesigns/jwt-auth/issues",
-        "source": "https://github.com/tymondesigns/jwt-auth"
+        "issues": "https://github.com/PHP-Open-Source-Saver/jwt-auth/issues",
+        "source": "https://github.com/PHP-Open-Source-Saver/jwt-auth"
     },
     "license": "MIT",
     "authors": [
@@ -19,6 +19,11 @@
             "name": "Sean Tymon",
             "email": "tymon148@gmail.com",
             "homepage": "https://tymon.xyz",
+            "role": "Developer"
+        },
+        {
+            "name": "Eric Schricker",
+            "email": "eric.schricker@adiutabyte.de",
             "role": "Developer"
         }
     ],
@@ -42,12 +47,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Tymon\\JWTAuth\\": "src/"
+            "PHPOpenSourceSaver\\JWTAuth\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Tymon\\JWTAuth\\Test\\": "tests/"
+            "PHPOpenSourceSaver\\JWTAuth\\Test\\": "tests/"
         }
     },
     "extra": {
@@ -56,20 +61,15 @@
         },
         "laravel": {
             "aliases": {
-                "JWTAuth": "Tymon\\JWTAuth\\Facades\\JWTAuth",
-                "JWTFactory": "Tymon\\JWTAuth\\Facades\\JWTFactory"
+                "JWTAuth": "PHPOpenSourceSaver\\JWTAuth\\Facades\\JWTAuth",
+                "JWTFactory": "PHPOpenSourceSaver\\JWTAuth\\Facades\\JWTFactory"
             },
             "providers": [
-                "Tymon\\JWTAuth\\Providers\\LaravelServiceProvider"
+                "PHPOpenSourceSaver\\JWTAuth\\Providers\\LaravelServiceProvider"
             ]
         }
     },
-    "funding": [
-        {
-            "type": "patreon",
-            "url": "https://www.patreon.com/seantymon"
-        }
-    ],
+    "funding": [],
     "config": {
         "sort-packages": true
     },

--- a/config/config.php
+++ b/config/config.php
@@ -275,7 +275,7 @@ return [
         |
         */
 
-        'jwt' => Tymon\JWTAuth\Providers\JWT\Lcobucci::class,
+        'jwt' => PHPOpenSourceSaver\JWTAuth\Providers\JWT\Lcobucci::class,
 
         /*
         |--------------------------------------------------------------------------
@@ -286,7 +286,7 @@ return [
         |
         */
 
-        'auth' => Tymon\JWTAuth\Providers\Auth\Illuminate::class,
+        'auth' => PHPOpenSourceSaver\JWTAuth\Providers\Auth\Illuminate::class,
 
         /*
         |--------------------------------------------------------------------------
@@ -297,7 +297,7 @@ return [
         |
         */
 
-        'storage' => Tymon\JWTAuth\Providers\Storage\Illuminate::class,
+        'storage' => PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate::class,
 
     ],
 

--- a/docs/auth-guard.md
+++ b/docs/auth-guard.md
@@ -52,13 +52,13 @@ Get the currently authenticated user or throw an exception.
 ```php
 try {
     $user = auth()->userOrFail();
-} catch (\Tymon\JWTAuth\Exceptions\UserNotDefinedException $e) {
+} catch (\PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException $e) {
     // do something
 }
 
 ```
 
-If the user is not set, then a `Tymon\JWTAuth\Exceptions\UserNotDefinedException` will be thrown
+If the user is not set, then a `PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException` will be thrown
 
 ### logout()
 

--- a/docs/laravel-installation.md
+++ b/docs/laravel-installation.md
@@ -17,7 +17,7 @@ Add the service provider to the `providers` array in the `config/app.php` config
 
     ...
 
-    Tymon\JWTAuth\Providers\LaravelServiceProvider::class,
+    PHPOpenSourceSaver\JWTAuth\Providers\LaravelServiceProvider::class,
 ]
 ```
 
@@ -28,7 +28,7 @@ Add the service provider to the `providers` array in the `config/app.php` config
 Run the following command to publish the package config file:
 
 ```bash
-php artisan vendor:publish --provider="Tymon\JWTAuth\Providers\LaravelServiceProvider"
+php artisan vendor:publish --provider="PHPOpenSourceSaver\JWTAuth\Providers\LaravelServiceProvider"
 ```
 
 You should now have a `config/jwt.php` file that allows you to configure the basics of this package.

--- a/docs/lumen-installation.md
+++ b/docs/lumen-installation.md
@@ -29,7 +29,7 @@ Add the following snippet to the `bootstrap/app.php` file under the providers se
 $app->register(App\Providers\AuthServiceProvider::class);
 
 // Add this line
-$app->register(Tymon\JWTAuth\Providers\LumenServiceProvider::class);
+$app->register(PHPOpenSourceSaver\JWTAuth\Providers\LumenServiceProvider::class);
 ```
 
 Then uncomment the `auth` middleware in the same file:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,7 +3,7 @@ Before continuing, make sure you have installed the package as per the installat
 
 ### Update your User model
 
-Firstly you need to implement the `Tymon\JWTAuth\Contracts\JWTSubject` contract on your User model,
+Firstly you need to implement the `PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject` contract on your User model,
 which requires that you implement the 2 methods `getJWTIdentifier()` and `getJWTCustomClaims()`.
 
 The example below should give you an idea of how this could look. Obviously you should make any
@@ -14,7 +14,7 @@ changes, as necessary, to suit your own needs.
 
 namespace App;
 
-use Tymon\JWTAuth\Contracts\JWTSubject;
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
-use Tymon\JWTAuth\Contracts\Providers\Storage;
-use Tymon\JWTAuth\Support\Utils;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage;
+use PHPOpenSourceSaver\JWTAuth\Support\Utils;
 
 class Blacklist
 {
     /**
      * The storage.
      *
-     * @var \Tymon\JWTAuth\Contracts\Providers\Storage
+     * @var \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage
      */
     protected $storage;
 
@@ -47,7 +47,7 @@ class Blacklist
     /**
      * Constructor.
      *
-     * @param  \Tymon\JWTAuth\Contracts\Providers\Storage  $storage
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage  $storage
      *
      * @return void
      */
@@ -59,7 +59,7 @@ class Blacklist
     /**
      * Add the token (jti claim) to the blacklist.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
      * @return bool
      */
@@ -88,7 +88,7 @@ class Blacklist
     /**
      * Get the number of minutes until the token expiry.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
      * @return int
      */
@@ -106,7 +106,7 @@ class Blacklist
     /**
      * Add the token (jti claim) to the blacklist indefinitely.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
      * @return bool
      */
@@ -120,7 +120,7 @@ class Blacklist
     /**
      * Determine whether the token has been blacklisted.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
      * @return bool
      */
@@ -140,7 +140,7 @@ class Blacklist
     /**
      * Remove the token (jti claim) from the blacklist.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
      * @return bool
      */
@@ -199,7 +199,7 @@ class Blacklist
     /**
      * Get the unique key held within the blacklist.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
      * @return mixed
      */

--- a/src/Claims/Audience.php
+++ b/src/Claims/Audience.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class Audience extends Claim
 {

--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
-use Tymon\JWTAuth\Contracts\Claim as ClaimContract;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Claim as ClaimContract;
 
 abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializable
 {
@@ -47,7 +47,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      *
      * @param  mixed  $value
      *
-     * @throws \Tymon\JWTAuth\Exceptions\InvalidClaimException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException
      *
      * @return $this
      */

--- a/src/Claims/Collection.php
+++ b/src/Claims/Collection.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 use Illuminate\Support\Collection as IlluminateCollection;
 use Illuminate\Support\Str;
@@ -35,7 +35,7 @@ class Collection extends IlluminateCollection
      * @param  callable  $callback
      * @param  mixed  $default
      *
-     * @return \Tymon\JWTAuth\Claims\Claim
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Claim
      */
     public function getByClaimName($name, callable $callback = null, $default = null)
     {

--- a/src/Claims/Custom.php
+++ b/src/Claims/Custom.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class Custom extends Claim
 {

--- a/src/Claims/DatetimeTrait.php
+++ b/src/Claims/DatetimeTrait.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 use DateInterval;
 use DateTimeInterface;
-use Tymon\JWTAuth\Exceptions\InvalidClaimException;
-use Tymon\JWTAuth\Support\Utils;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
+use PHPOpenSourceSaver\JWTAuth\Support\Utils;
 
 trait DatetimeTrait
 {
@@ -30,7 +30,7 @@ trait DatetimeTrait
      *
      * @param  mixed  $value
      *
-     * @throws \Tymon\JWTAuth\Exceptions\InvalidClaimException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException
      *
      * @return $this
      */

--- a/src/Claims/Expiration.php
+++ b/src/Claims/Expiration.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
-use Tymon\JWTAuth\Exceptions\TokenExpiredException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException;
 
 class Expiration extends Claim
 {

--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use Tymon\JWTAuth\Support\Utils;
+use PHPOpenSourceSaver\JWTAuth\Support\Utils;
 
 class Factory
 {
@@ -71,7 +71,7 @@ class Factory
      * @param  string  $name
      * @param  mixed  $value
      *
-     * @return \Tymon\JWTAuth\Claims\Claim
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Claim
      */
     public function get($name, $value)
     {
@@ -103,7 +103,7 @@ class Factory
      *
      * @param  string  $name
      *
-     * @return \Tymon\JWTAuth\Claims\Claim
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Claim
      */
     public function make($name)
     {

--- a/src/Claims/IssuedAt.php
+++ b/src/Claims/IssuedAt.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
-use Tymon\JWTAuth\Exceptions\InvalidClaimException;
-use Tymon\JWTAuth\Exceptions\TokenExpiredException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 
 class IssuedAt extends Claim
 {

--- a/src/Claims/Issuer.php
+++ b/src/Claims/Issuer.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class Issuer extends Claim
 {

--- a/src/Claims/JwtId.php
+++ b/src/Claims/JwtId.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class JwtId extends Claim
 {

--- a/src/Claims/NotBefore.php
+++ b/src/Claims/NotBefore.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 
 class NotBefore extends Claim
 {

--- a/src/Claims/Subject.php
+++ b/src/Claims/Subject.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class Subject extends Claim
 {

--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Console;
+namespace PHPOpenSourceSaver\JWTAuth\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/src/Contracts/Claim.php
+++ b/src/Contracts/Claim.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Contracts;
+namespace PHPOpenSourceSaver\JWTAuth\Contracts;
 
 interface Claim
 {
@@ -18,7 +18,7 @@ interface Claim
      *
      * @param  mixed  $value
      *
-     * @throws \Tymon\JWTAuth\Exceptions\InvalidClaimException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException
      *
      * @return $this
      */

--- a/src/Contracts/Http/Parser.php
+++ b/src/Contracts/Http/Parser.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Contracts\Http;
+namespace PHPOpenSourceSaver\JWTAuth\Contracts\Http;
 
 use Illuminate\Http\Request;
 

--- a/src/Contracts/JWTSubject.php
+++ b/src/Contracts/JWTSubject.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Contracts;
+namespace PHPOpenSourceSaver\JWTAuth\Contracts;
 
 interface JWTSubject
 {

--- a/src/Contracts/Providers/Auth.php
+++ b/src/Contracts/Providers/Auth.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Contracts\Providers;
+namespace PHPOpenSourceSaver\JWTAuth\Contracts\Providers;
 
 interface Auth
 {

--- a/src/Contracts/Providers/JWT.php
+++ b/src/Contracts/Providers/JWT.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Contracts\Providers;
+namespace PHPOpenSourceSaver\JWTAuth\Contracts\Providers;
 
 interface JWT
 {

--- a/src/Contracts/Providers/Storage.php
+++ b/src/Contracts/Providers/Storage.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Contracts\Providers;
+namespace PHPOpenSourceSaver\JWTAuth\Contracts\Providers;
 
 interface Storage
 {

--- a/src/Contracts/Validator.php
+++ b/src/Contracts/Validator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Contracts;
+namespace PHPOpenSourceSaver\JWTAuth\Contracts;
 
 interface Validator
 {

--- a/src/Exceptions/InvalidClaimException.php
+++ b/src/Exceptions/InvalidClaimException.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Exceptions;
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 use Exception;
-use Tymon\JWTAuth\Claims\Claim;
+use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
 
 class InvalidClaimException extends JWTException
 {
     /**
      * Constructor.
      *
-     * @param  \Tymon\JWTAuth\Claims\Claim  $claim
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Claim  $claim
      * @param  int  $code
      * @param  \Exception|null  $previous
      *

--- a/src/Exceptions/JWTException.php
+++ b/src/Exceptions/JWTException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Exceptions;
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/PayloadException.php
+++ b/src/Exceptions/PayloadException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Exceptions;
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class PayloadException extends JWTException
 {

--- a/src/Exceptions/TokenBlacklistedException.php
+++ b/src/Exceptions/TokenBlacklistedException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Exceptions;
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class TokenBlacklistedException extends TokenInvalidException
 {

--- a/src/Exceptions/TokenExpiredException.php
+++ b/src/Exceptions/TokenExpiredException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Exceptions;
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class TokenExpiredException extends JWTException
 {

--- a/src/Exceptions/TokenInvalidException.php
+++ b/src/Exceptions/TokenInvalidException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Exceptions;
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class TokenInvalidException extends JWTException
 {

--- a/src/Exceptions/UserNotDefinedException.php
+++ b/src/Exceptions/UserNotDefinedException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Exceptions;
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class UserNotDefinedException extends JWTException
 {

--- a/src/Facades/JWTAuth.php
+++ b/src/Facades/JWTAuth.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Facades;
+namespace PHPOpenSourceSaver\JWTAuth\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/Facades/JWTFactory.php
+++ b/src/Facades/JWTFactory.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Facades;
+namespace PHPOpenSourceSaver\JWTAuth\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/Facades/JWTProvider.php
+++ b/src/Facades/JWTProvider.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Facades;
+namespace PHPOpenSourceSaver\JWTAuth\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
-use Tymon\JWTAuth\Claims\Claim;
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Factory as ClaimFactory;
-use Tymon\JWTAuth\Support\CustomClaims;
-use Tymon\JWTAuth\Support\RefreshFlow;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Factory as ClaimFactory;
+use PHPOpenSourceSaver\JWTAuth\Support\CustomClaims;
+use PHPOpenSourceSaver\JWTAuth\Support\RefreshFlow;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class Factory
 {
@@ -25,14 +25,14 @@ class Factory
     /**
      * The claim factory.
      *
-     * @var \Tymon\JWTAuth\Claims\Factory
+     * @var \PHPOpenSourceSaver\JWTAuth\Claims\Factory
      */
     protected $claimFactory;
 
     /**
      * The validator.
      *
-     * @var \Tymon\JWTAuth\Validators\PayloadValidator
+     * @var \PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator
      */
     protected $validator;
 
@@ -52,15 +52,15 @@ class Factory
     /**
      * The claims collection.
      *
-     * @var \Tymon\JWTAuth\Claims\Collection
+     * @var \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     protected $claims;
 
     /**
      * Constructor.
      *
-     * @param  \Tymon\JWTAuth\Claims\Factory  $claimFactory
-     * @param  \Tymon\JWTAuth\Validators\PayloadValidator  $validator
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Factory  $claimFactory
+     * @param  \PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator  $validator
      *
      * @return void
      */
@@ -76,7 +76,7 @@ class Factory
      *
      * @param  bool  $resetClaims
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function make($resetClaims = false)
     {
@@ -154,7 +154,7 @@ class Factory
     /**
      * Build out the Claim DTO's.
      *
-     * @return \Tymon\JWTAuth\Claims\Collection
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     protected function resolveClaims()
     {
@@ -166,7 +166,7 @@ class Factory
     /**
      * Build and get the Claims Collection.
      *
-     * @return \Tymon\JWTAuth\Claims\Collection
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     public function buildClaimsCollection()
     {
@@ -176,9 +176,9 @@ class Factory
     /**
      * Get a Payload instance with a claims collection.
      *
-     * @param  \Tymon\JWTAuth\Claims\Collection  $claims
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Collection  $claims
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function withClaims(Collection $claims)
     {
@@ -236,7 +236,7 @@ class Factory
     /**
      * Get the PayloadValidator instance.
      *
-     * @return \Tymon\JWTAuth\Validators\PayloadValidator
+     * @return \PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator
      */
     public function validator()
     {

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
 use Closure;
 

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
 use Closure;
 

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\JWTAuth;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\JWTAuth;
 
 /** @deprecated */
 abstract class BaseMiddleware
@@ -22,14 +22,14 @@ abstract class BaseMiddleware
     /**
      * The JWT Authenticator.
      *
-     * @var \Tymon\JWTAuth\JWTAuth
+     * @var \PHPOpenSourceSaver\JWTAuth\JWTAuth
      */
     protected $auth;
 
     /**
      * Create a new BaseMiddleware instance.
      *
-     * @param  \Tymon\JWTAuth\JWTAuth  $auth
+     * @param  \PHPOpenSourceSaver\JWTAuth\JWTAuth  $auth
      *
      * @return void
      */

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
 use Closure;
 use Exception;

--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
 use Closure;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Tymon\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 
 /** @deprecated */
 class RefreshToken extends BaseMiddleware

--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
-use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser as ParserContract;
 
 class AuthHeaders implements ParserContract
 {

--- a/src/Http/Parser/Cookies.php
+++ b/src/Http/Parser/Cookies.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Crypt;
-use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser as ParserContract;
 
 class Cookies implements ParserContract
 {

--- a/src/Http/Parser/InputSource.php
+++ b/src/Http/Parser/InputSource.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
-use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser as ParserContract;
 
 class InputSource implements ParserContract
 {

--- a/src/Http/Parser/KeyTrait.php
+++ b/src/Http/Parser/KeyTrait.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 trait KeyTrait
 {

--- a/src/Http/Parser/LumenRouteParams.php
+++ b/src/Http/Parser/LumenRouteParams.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;

--- a/src/Http/Parser/Parser.php
+++ b/src/Http/Parser/Parser.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
 
@@ -56,7 +56,7 @@ class Parser
     /**
      * Add a new parser to the chain.
      *
-     * @param array|\Tymon\JWTAuth\Contracts\Http\Parser $parsers
+     * @param array|\PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser $parsers
      *
      * @return $this
      */

--- a/src/Http/Parser/QueryString.php
+++ b/src/Http/Parser/QueryString.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
-use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser as ParserContract;
 
 class QueryString implements ParserContract
 {

--- a/src/Http/Parser/RouteParams.php
+++ b/src/Http/Parser/RouteParams.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Http\Parser;
+namespace PHPOpenSourceSaver\JWTAuth\Http\Parser;
 
 use Illuminate\Http\Request;
-use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser as ParserContract;
 
 class RouteParams implements ParserContract
 {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
 use BadMethodCallException;
 use Illuminate\Http\Request;
-use Tymon\JWTAuth\Contracts\JWTSubject;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Http\Parser\Parser;
-use Tymon\JWTAuth\Support\CustomClaims;
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Support\CustomClaims;
 
 class JWT
 {
@@ -25,21 +25,21 @@ class JWT
     /**
      * The authentication manager.
      *
-     * @var \Tymon\JWTAuth\Manager
+     * @var \PHPOpenSourceSaver\JWTAuth\Manager
      */
     protected $manager;
 
     /**
      * The HTTP parser.
      *
-     * @var \Tymon\JWTAuth\Http\Parser\Parser
+     * @var \PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser
      */
     protected $parser;
 
     /**
      * The token.
      *
-     * @var \Tymon\JWTAuth\Token|null
+     * @var \PHPOpenSourceSaver\JWTAuth\Token|null
      */
     protected $token;
 
@@ -53,8 +53,8 @@ class JWT
     /**
      * JWT constructor.
      *
-     * @param  \Tymon\JWTAuth\Manager  $manager
-     * @param  \Tymon\JWTAuth\Http\Parser\Parser  $parser
+     * @param  \PHPOpenSourceSaver\JWTAuth\Manager  $manager
+     * @param  \PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser  $parser
      *
      * @return void
      */
@@ -67,7 +67,7 @@ class JWT
     /**
      * Generate a token for a given subject.
      *
-     * @param  \Tymon\JWTAuth\Contracts\JWTSubject  $subject
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject  $subject
      *
      * @return string
      */
@@ -81,7 +81,7 @@ class JWT
     /**
      * Alias to generate a token for a given user.
      *
-     * @param  \Tymon\JWTAuth\Contracts\JWTSubject  $user
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject  $user
      *
      * @return string
      */
@@ -127,9 +127,9 @@ class JWT
      * Alias to get the payload, and as a result checks that
      * the token is valid i.e. not expired or blacklisted.
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function checkOrFail()
     {
@@ -141,7 +141,7 @@ class JWT
      *
      * @param  bool  $getPayload
      *
-     * @return \Tymon\JWTAuth\Payload|bool
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload|bool
      */
     public function check($getPayload = false)
     {
@@ -157,7 +157,7 @@ class JWT
     /**
      * Get the token.
      *
-     * @return \Tymon\JWTAuth\Token|null
+     * @return \PHPOpenSourceSaver\JWTAuth\Token|null
      */
     public function getToken()
     {
@@ -175,7 +175,7 @@ class JWT
     /**
      * Parse the token from the request.
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return $this
      */
@@ -191,7 +191,7 @@ class JWT
     /**
      * Get the raw Payload instance.
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function getPayload()
     {
@@ -203,7 +203,7 @@ class JWT
     /**
      * Alias for getPayload().
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function payload()
     {
@@ -225,9 +225,9 @@ class JWT
     /**
      * Create a Payload instance.
      *
-     * @param  \Tymon\JWTAuth\Contracts\JWTSubject  $subject
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject  $subject
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function makePayload(JWTSubject $subject)
     {
@@ -237,7 +237,7 @@ class JWT
     /**
      * Build the claims array and return it.
      *
-     * @param  \Tymon\JWTAuth\Contracts\JWTSubject  $subject
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject  $subject
      *
      * @return array
      */
@@ -253,7 +253,7 @@ class JWT
     /**
      * Get the claims associated with a given subject.
      *
-     * @param  \Tymon\JWTAuth\Contracts\JWTSubject  $subject
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject  $subject
      *
      * @return array
      */
@@ -295,7 +295,7 @@ class JWT
     /**
      * Set the token.
      *
-     * @param  \Tymon\JWTAuth\Token|string  $token
+     * @param  \PHPOpenSourceSaver\JWTAuth\Token|string  $token
      *
      * @return $this
      */
@@ -321,7 +321,7 @@ class JWT
     /**
      * Ensure that a token is available.
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return void
      */
@@ -363,7 +363,7 @@ class JWT
     /**
      * Get the Manager instance.
      *
-     * @return \Tymon\JWTAuth\Manager
+     * @return \PHPOpenSourceSaver\JWTAuth\Manager
      */
     public function manager()
     {
@@ -373,7 +373,7 @@ class JWT
     /**
      * Get the Parser instance.
      *
-     * @return \Tymon\JWTAuth\Http\Parser\Parser
+     * @return \PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser
      */
     public function parser()
     {
@@ -383,7 +383,7 @@ class JWT
     /**
      * Get the Payload Factory.
      *
-     * @return \Tymon\JWTAuth\Factory
+     * @return \PHPOpenSourceSaver\JWTAuth\Factory
      */
     public function factory()
     {
@@ -393,7 +393,7 @@ class JWT
     /**
      * Get the Blacklist.
      *
-     * @return \Tymon\JWTAuth\Blacklist
+     * @return \PHPOpenSourceSaver\JWTAuth\Blacklist
      */
     public function blacklist()
     {

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
-use Tymon\JWTAuth\Contracts\Providers\Auth;
-use Tymon\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
 
 /** @deprecated */
 class JWTAuth extends JWT
@@ -20,16 +20,16 @@ class JWTAuth extends JWT
     /**
      * The authentication provider.
      *
-     * @var \Tymon\JWTAuth\Contracts\Providers\Auth
+     * @var \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth
      */
     protected $auth;
 
     /**
      * Constructor.
      *
-     * @param  \Tymon\JWTAuth\Manager  $manager
-     * @param  \Tymon\JWTAuth\Contracts\Providers\Auth  $auth
-     * @param  \Tymon\JWTAuth\Http\Parser\Parser  $parser
+     * @param  \PHPOpenSourceSaver\JWTAuth\Manager  $manager
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth  $auth
+     * @param  \PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser  $parser
      *
      * @return void
      */
@@ -58,7 +58,7 @@ class JWTAuth extends JWT
     /**
      * Authenticate a user via a token.
      *
-     * @return \Tymon\JWTAuth\Contracts\JWTSubject|false
+     * @return \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject|false
      */
     public function authenticate()
     {
@@ -74,7 +74,7 @@ class JWTAuth extends JWT
     /**
      * Alias for authenticate().
      *
-     * @return \Tymon\JWTAuth\Contracts\JWTSubject|false
+     * @return \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject|false
      */
     public function toUser()
     {
@@ -84,7 +84,7 @@ class JWTAuth extends JWT
     /**
      * Get the authenticated user.
      *
-     * @return \Tymon\JWTAuth\Contracts\JWTSubject
+     * @return \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject
      */
     public function user()
     {

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
 use BadMethodCallException;
 use Illuminate\Auth\GuardHelpers;
@@ -17,9 +17,9 @@ use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Traits\Macroable;
-use Tymon\JWTAuth\Contracts\JWTSubject;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\UserNotDefinedException;
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException;
 
 class JWTGuard implements Guard
 {
@@ -37,7 +37,7 @@ class JWTGuard implements Guard
     /**
      * The JWT instance.
      *
-     * @var \Tymon\JWTAuth\JWT
+     * @var \PHPOpenSourceSaver\JWTAuth\JWT
      */
     protected $jwt;
 
@@ -51,7 +51,7 @@ class JWTGuard implements Guard
     /**
      * Instantiate the class.
      *
-     * @param  \Tymon\JWTAuth\JWT  $jwt
+     * @param  \PHPOpenSourceSaver\JWTAuth\JWT  $jwt
      * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
      * @param  \Illuminate\Http\Request  $request
      *
@@ -86,7 +86,7 @@ class JWTGuard implements Guard
     /**
      * Get the currently authenticated user or throws an exception.
      *
-     * @throws \Tymon\JWTAuth\Exceptions\UserNotDefinedException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
@@ -133,7 +133,7 @@ class JWTGuard implements Guard
     /**
      * Create a token for a user.
      *
-     * @param  \Tymon\JWTAuth\Contracts\JWTSubject  $user
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject  $user
      *
      * @return string
      */
@@ -178,7 +178,7 @@ class JWTGuard implements Guard
      *
      * @param  bool  $forceForever
      *
-     * @return \Tymon\JWTAuth\JWT
+     * @return \PHPOpenSourceSaver\JWTAuth\JWT
      */
     public function invalidate($forceForever = false)
     {
@@ -264,7 +264,7 @@ class JWTGuard implements Guard
     /**
      * Get the raw Payload instance.
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function getPayload()
     {
@@ -274,7 +274,7 @@ class JWTGuard implements Guard
     /**
      * Alias for getPayload().
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function payload()
     {
@@ -284,7 +284,7 @@ class JWTGuard implements Guard
     /**
      * Set the token.
      *
-     * @param  \Tymon\JWTAuth\Token|string  $token
+     * @param  \PHPOpenSourceSaver\JWTAuth\Token|string  $token
      *
      * @return $this
      */
@@ -409,9 +409,9 @@ class JWTGuard implements Guard
     /**
      * Ensure that a token is available in the request.
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
-     * @return \Tymon\JWTAuth\JWT
+     * @return \PHPOpenSourceSaver\JWTAuth\JWT
      */
     protected function requireToken()
     {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
-use Tymon\JWTAuth\Contracts\Providers\JWT as JWTContract;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenBlacklistedException;
-use Tymon\JWTAuth\Support\CustomClaims;
-use Tymon\JWTAuth\Support\RefreshFlow;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT as JWTContract;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException;
+use PHPOpenSourceSaver\JWTAuth\Support\CustomClaims;
+use PHPOpenSourceSaver\JWTAuth\Support\RefreshFlow;
 
 class Manager
 {
@@ -24,21 +24,21 @@ class Manager
     /**
      * The provider.
      *
-     * @var \Tymon\JWTAuth\Contracts\Providers\JWT
+     * @var \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT
      */
     protected $provider;
 
     /**
      * The blacklist.
      *
-     * @var \Tymon\JWTAuth\Blacklist
+     * @var \PHPOpenSourceSaver\JWTAuth\Blacklist
      */
     protected $blacklist;
 
     /**
      * the payload factory.
      *
-     * @var \Tymon\JWTAuth\Factory
+     * @var \PHPOpenSourceSaver\JWTAuth\Factory
      */
     protected $payloadFactory;
 
@@ -59,9 +59,9 @@ class Manager
     /**
      * Constructor.
      *
-     * @param  \Tymon\JWTAuth\Contracts\Providers\JWT  $provider
-     * @param  \Tymon\JWTAuth\Blacklist  $blacklist
-     * @param  \Tymon\JWTAuth\Factory  $payloadFactory
+     * @param  \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT  $provider
+     * @param  \PHPOpenSourceSaver\JWTAuth\Blacklist  $blacklist
+     * @param  \PHPOpenSourceSaver\JWTAuth\Factory  $payloadFactory
      *
      * @return void
      */
@@ -75,9 +75,9 @@ class Manager
     /**
      * Encode a Payload and return the Token.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
-     * @return \Tymon\JWTAuth\Token
+     * @return \PHPOpenSourceSaver\JWTAuth\Token
      */
     public function encode(Payload $payload)
     {
@@ -89,12 +89,12 @@ class Manager
     /**
      * Decode a Token and return the Payload.
      *
-     * @param  \Tymon\JWTAuth\Token  $token
+     * @param  \PHPOpenSourceSaver\JWTAuth\Token  $token
      * @param  bool  $checkBlacklist
      *
-     * @throws \Tymon\JWTAuth\Exceptions\TokenBlacklistedException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     public function decode(Token $token, $checkBlacklist = true)
     {
@@ -115,11 +115,11 @@ class Manager
     /**
      * Refresh a Token and return a new Token.
      *
-     * @param  \Tymon\JWTAuth\Token  $token
+     * @param  \PHPOpenSourceSaver\JWTAuth\Token  $token
      * @param  bool  $forceForever
      * @param  bool  $resetClaims
      *
-     * @return \Tymon\JWTAuth\Token
+     * @return \PHPOpenSourceSaver\JWTAuth\Token
      */
     public function refresh(Token $token, $forceForever = false, $resetClaims = false)
     {
@@ -141,10 +141,10 @@ class Manager
     /**
      * Invalidate a Token by adding it to the blacklist.
      *
-     * @param  \Tymon\JWTAuth\Token  $token
+     * @param  \PHPOpenSourceSaver\JWTAuth\Token  $token
      * @param  bool  $forceForever
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return bool
      */
@@ -163,7 +163,7 @@ class Manager
     /**
      * Build the claims to go into the refreshed token.
      *
-     * @param  \Tymon\JWTAuth\Payload  $payload
+     * @param  \PHPOpenSourceSaver\JWTAuth\Payload  $payload
      *
      * @return array
      */
@@ -188,7 +188,7 @@ class Manager
     /**
      * Get the Payload Factory instance.
      *
-     * @return \Tymon\JWTAuth\Factory
+     * @return \PHPOpenSourceSaver\JWTAuth\Factory
      */
     public function getPayloadFactory()
     {
@@ -198,7 +198,7 @@ class Manager
     /**
      * Get the JWTProvider instance.
      *
-     * @return \Tymon\JWTAuth\Contracts\Providers\JWT
+     * @return \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT
      */
     public function getJWTProvider()
     {
@@ -208,7 +208,7 @@ class Manager
     /**
      * Get the Blacklist instance.
      *
-     * @return \Tymon\JWTAuth\Blacklist
+     * @return \PHPOpenSourceSaver\JWTAuth\Blacklist
      */
     public function getBlacklist()
     {

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
 use ArrayAccess;
 use BadMethodCallException;
@@ -19,25 +19,25 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use JsonSerializable;
-use Tymon\JWTAuth\Claims\Claim;
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Exceptions\PayloadException;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\PayloadException;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerializable
 {
     /**
      * The collection of claims.
      *
-     * @var \Tymon\JWTAuth\Claims\Collection
+     * @var \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     private $claims;
 
     /**
      * Build the Payload.
      *
-     * @param  \Tymon\JWTAuth\Claims\Collection  $claims
-     * @param  \Tymon\JWTAuth\Validators\PayloadValidator  $validator
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Collection  $claims
+     * @param  \PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator  $validator
      * @param  bool  $refreshFlow
      *
      * @return void
@@ -50,7 +50,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Get the array of claim instances.
      *
-     * @return \Tymon\JWTAuth\Claims\Collection
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     public function getClaims()
     {
@@ -121,7 +121,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @param  string  $claim
      *
-     * @return \Tymon\JWTAuth\Claims\Claim
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Claim
      */
     public function getInternal($claim)
     {
@@ -131,7 +131,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Determine whether the payload has the claim (by instance).
      *
-     * @param  \Tymon\JWTAuth\Claims\Claim  $claim
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Claim  $claim
      *
      * @return bool
      */
@@ -224,7 +224,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      * @param  mixed  $key
      * @param  mixed  $value
      *
-     * @throws \Tymon\JWTAuth\Exceptions\PayloadException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\PayloadException
      */
     public function offsetSet($key, $value)
     {
@@ -236,7 +236,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @param  string  $key
      *
-     * @throws \Tymon\JWTAuth\Exceptions\PayloadException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\PayloadException
      *
      * @return void
      */
@@ -281,7 +281,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     {
         if (preg_match('/get(.+)\b/i', $method, $matches)) {
             foreach ($this->claims as $claim) {
-                if (get_class($claim) === 'Tymon\\JWTAuth\\Claims\\'.$matches[1]) {
+                if (get_class($claim) === 'PHPOpenSourceSaver\\JWTAuth\\Claims\\'.$matches[1]) {
                     return $claim->getValue();
                 }
             }

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -9,34 +9,34 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers;
+namespace PHPOpenSourceSaver\JWTAuth\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Lcobucci\JWT\Builder as JWTBuilder;
 use Lcobucci\JWT\Parser as JWTParser;
 use Namshi\JOSE\JWS;
-use Tymon\JWTAuth\Blacklist;
-use Tymon\JWTAuth\Claims\Factory as ClaimFactory;
-use Tymon\JWTAuth\Console\JWTGenerateSecretCommand;
-use Tymon\JWTAuth\Contracts\Providers\Auth;
-use Tymon\JWTAuth\Contracts\Providers\JWT as JWTContract;
-use Tymon\JWTAuth\Contracts\Providers\Storage;
-use Tymon\JWTAuth\Factory;
-use Tymon\JWTAuth\Http\Middleware\Authenticate;
-use Tymon\JWTAuth\Http\Middleware\AuthenticateAndRenew;
-use Tymon\JWTAuth\Http\Middleware\Check;
-use Tymon\JWTAuth\Http\Middleware\RefreshToken;
-use Tymon\JWTAuth\Http\Parser\AuthHeaders;
-use Tymon\JWTAuth\Http\Parser\InputSource;
-use Tymon\JWTAuth\Http\Parser\Parser;
-use Tymon\JWTAuth\Http\Parser\QueryString;
-use Tymon\JWTAuth\JWT;
-use Tymon\JWTAuth\JWTAuth;
-use Tymon\JWTAuth\JWTGuard;
-use Tymon\JWTAuth\Manager;
-use Tymon\JWTAuth\Providers\JWT\Lcobucci;
-use Tymon\JWTAuth\Providers\JWT\Namshi;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Blacklist;
+use PHPOpenSourceSaver\JWTAuth\Claims\Factory as ClaimFactory;
+use PHPOpenSourceSaver\JWTAuth\Console\JWTGenerateSecretCommand;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT as JWTContract;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage;
+use PHPOpenSourceSaver\JWTAuth\Factory;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\Authenticate;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\AuthenticateAndRenew;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\Check;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\RefreshToken;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\AuthHeaders;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\InputSource;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\QueryString;
+use PHPOpenSourceSaver\JWTAuth\JWT;
+use PHPOpenSourceSaver\JWTAuth\JWTAuth;
+use PHPOpenSourceSaver\JWTAuth\JWTGuard;
+use PHPOpenSourceSaver\JWTAuth\Manager;
+use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Lcobucci;
+use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Namshi;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 abstract class AbstractServiceProvider extends ServiceProvider
 {

--- a/src/Providers/Auth/Illuminate.php
+++ b/src/Providers/Auth/Illuminate.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers\Auth;
+namespace PHPOpenSourceSaver\JWTAuth\Providers\Auth;
 
 use Illuminate\Contracts\Auth\Guard as GuardContract;
-use Tymon\JWTAuth\Contracts\Providers\Auth;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
 
 class Illuminate implements Auth
 {

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers\JWT;
+namespace PHPOpenSourceSaver\JWTAuth\Providers\JWT;
 
 use Exception;
 use Illuminate\Support\Collection;
@@ -28,9 +28,9 @@ use Lcobucci\JWT\Signer\Rsa\Sha256 as RS256;
 use Lcobucci\JWT\Signer\Rsa\Sha384 as RS384;
 use Lcobucci\JWT\Signer\Rsa\Sha512 as RS512;
 use ReflectionClass;
-use Tymon\JWTAuth\Contracts\Providers\JWT;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 
 class Lcobucci extends Provider implements JWT
 {
@@ -95,7 +95,7 @@ class Lcobucci extends Provider implements JWT
      *
      * @param  array  $payload
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return string
      */
@@ -121,7 +121,7 @@ class Lcobucci extends Provider implements JWT
      *
      * @param  string  $token
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return array
      */
@@ -145,7 +145,7 @@ class Lcobucci extends Provider implements JWT
     /**
      * Get the signer instance.
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return \Lcobucci\JWT\Signer
      */

--- a/src/Providers/JWT/Namshi.php
+++ b/src/Providers/JWT/Namshi.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers\JWT;
+namespace PHPOpenSourceSaver\JWTAuth\Providers\JWT;
 
 use Exception;
 use InvalidArgumentException;
@@ -17,9 +17,9 @@ use Namshi\JOSE\JWS;
 use Namshi\JOSE\Signer\OpenSSL\PublicKey;
 use ReflectionClass;
 use ReflectionException;
-use Tymon\JWTAuth\Contracts\Providers\JWT;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 
 class Namshi extends Provider implements JWT
 {
@@ -52,7 +52,7 @@ class Namshi extends Provider implements JWT
      *
      * @param  array  $payload
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return string
      */
@@ -72,7 +72,7 @@ class Namshi extends Provider implements JWT
      *
      * @param  string  $token
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return array
      */

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers\JWT;
+namespace PHPOpenSourceSaver\JWTAuth\Providers\JWT;
 
 use Illuminate\Support\Arr;
 
@@ -182,7 +182,7 @@ abstract class Provider
      * Determine if the algorithm is asymmetric, and thus
      * requires a public/private key combo.
      *
-     * @throws \Tymon\JWTAuth\Exceptions\JWTException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
      * @return bool
      */

--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers;
+namespace PHPOpenSourceSaver\JWTAuth\Providers;
 
-use Tymon\JWTAuth\Http\Parser\Cookies;
-use Tymon\JWTAuth\Http\Parser\RouteParams;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Cookies;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\RouteParams;
 
 class LaravelServiceProvider extends AbstractServiceProvider
 {

--- a/src/Providers/LumenServiceProvider.php
+++ b/src/Providers/LumenServiceProvider.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers;
+namespace PHPOpenSourceSaver\JWTAuth\Providers;
 
-use Tymon\JWTAuth\Http\Parser\LumenRouteParams;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\LumenRouteParams;
 
 class LumenServiceProvider extends AbstractServiceProvider
 {

--- a/src/Providers/Storage/Illuminate.php
+++ b/src/Providers/Storage/Illuminate.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Providers\Storage;
+namespace PHPOpenSourceSaver\JWTAuth\Providers\Storage;
 
 use BadMethodCallException;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Psr\SimpleCache\CacheInterface as PsrCacheInterface;
-use Tymon\JWTAuth\Contracts\Providers\Storage;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage;
 
 class Illuminate implements Storage
 {

--- a/src/Support/CustomClaims.php
+++ b/src/Support/CustomClaims.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Support;
+namespace PHPOpenSourceSaver\JWTAuth\Support;
 
 trait CustomClaims
 {

--- a/src/Support/RefreshFlow.php
+++ b/src/Support/RefreshFlow.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Support;
+namespace PHPOpenSourceSaver\JWTAuth\Support;
 
 trait RefreshFlow
 {

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Support;
+namespace PHPOpenSourceSaver\JWTAuth\Support;
 
 use Carbon\Carbon;
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth;
+namespace PHPOpenSourceSaver\JWTAuth;
 
-use Tymon\JWTAuth\Validators\TokenValidator;
+use PHPOpenSourceSaver\JWTAuth\Validators\TokenValidator;
 
 class Token
 {

--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Validators;
+namespace PHPOpenSourceSaver\JWTAuth\Validators;
 
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 
 class PayloadValidator extends Validator
 {
@@ -40,9 +40,9 @@ class PayloadValidator extends Validator
     /**
      * Run the validations on the payload array.
      *
-     * @param  \Tymon\JWTAuth\Claims\Collection  $value
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Collection  $value
      *
-     * @return \Tymon\JWTAuth\Claims\Collection
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     public function check($value)
     {
@@ -55,9 +55,9 @@ class PayloadValidator extends Validator
      * Ensure the payload contains the required claims and
      * the claims have the relevant type.
      *
-     * @param  \Tymon\JWTAuth\Claims\Collection  $claims
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Collection  $claims
      *
-     * @throws \Tymon\JWTAuth\Exceptions\TokenInvalidException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
      *
      * @return void
      */
@@ -71,12 +71,12 @@ class PayloadValidator extends Validator
     /**
      * Validate the payload timestamps.
      *
-     * @param  \Tymon\JWTAuth\Claims\Collection  $claims
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Collection  $claims
      *
-     * @throws \Tymon\JWTAuth\Exceptions\TokenExpiredException
-     * @throws \Tymon\JWTAuth\Exceptions\TokenInvalidException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
      *
-     * @return \Tymon\JWTAuth\Claims\Collection
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     protected function validatePayload(Collection $claims)
     {
@@ -86,11 +86,11 @@ class PayloadValidator extends Validator
     /**
      * Check the token in the refresh flow context.
      *
-     * @param  \Tymon\JWTAuth\Claims\Collection  $claims
+     * @param  \PHPOpenSourceSaver\JWTAuth\Claims\Collection  $claims
      *
-     * @throws \Tymon\JWTAuth\Exceptions\TokenExpiredException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException
      *
-     * @return \Tymon\JWTAuth\Claims\Collection
+     * @return \PHPOpenSourceSaver\JWTAuth\Claims\Collection
      */
     protected function validateRefresh(Collection $claims)
     {

--- a/src/Validators/TokenValidator.php
+++ b/src/Validators/TokenValidator.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Validators;
+namespace PHPOpenSourceSaver\JWTAuth\Validators;
 
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 
 class TokenValidator extends Validator
 {
@@ -30,7 +30,7 @@ class TokenValidator extends Validator
     /**
      * @param  string  $token
      *
-     * @throws \Tymon\JWTAuth\Exceptions\TokenInvalidException
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
      *
      * @return string
      */

--- a/src/Validators/Validator.php
+++ b/src/Validators/Validator.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Validators;
+namespace PHPOpenSourceSaver\JWTAuth\Validators;
 
-use Tymon\JWTAuth\Contracts\Validator as ValidatorContract;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Support\RefreshFlow;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Validator as ValidatorContract;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Support\RefreshFlow;
 
 abstract class Validator implements ValidatorContract
 {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Carbon\Carbon;
 use Mockery;

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -9,35 +9,35 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
-use Tymon\JWTAuth\Blacklist;
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Contracts\Providers\Storage;
-use Tymon\JWTAuth\Payload;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Blacklist;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage;
+use PHPOpenSourceSaver\JWTAuth\Payload;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class BlacklistTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\Contracts\Providers\Storage|\Mockery\MockInterface
+     * @var \PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage|\Mockery\MockInterface
      */
     protected $storage;
 
     /**
-     * @var \Tymon\JWTAuth\Blacklist
+     * @var \PHPOpenSourceSaver\JWTAuth\Blacklist
      */
     protected $blacklist;
 
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Validators\Validator
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Validators\Validator
      */
     protected $validator;
 

--- a/tests/Claims/ClaimTest.php
+++ b/tests/Claims/ClaimTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Claims;
 
 use Illuminate\Contracts\Support\Arrayable;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Exceptions\InvalidClaimException;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class ClaimTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\Claims\Expiration
+     * @var \PHPOpenSourceSaver\JWTAuth\Claims\Expiration
      */
     protected $claim;
 

--- a/tests/Claims/CollectionTest.php
+++ b/tests/Claims/CollectionTest.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Claims;
 
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class CollectionTest extends AbstractTestCase
 {

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Claims;
 
 use Carbon\Carbon;
 use DateInterval;
@@ -17,21 +17,21 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Mockery;
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Payload;
-use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Payload;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class DatetimeClaimTest extends AbstractTestCase
 {
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Validators\PayloadValidator
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator
      */
     protected $validator;
 

--- a/tests/Claims/FactoryTest.php
+++ b/tests/Claims/FactoryTest.php
@@ -9,24 +9,24 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Claims;
 
 use Illuminate\Http\Request;
-use Tymon\JWTAuth\Claims\Custom;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\Factory;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Test\Fixtures\Foo;
+use PHPOpenSourceSaver\JWTAuth\Claims\Custom;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\Factory;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Test\Fixtures\Foo;
 
 class FactoryTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\Claims\Factory
+     * @var \PHPOpenSourceSaver\JWTAuth\Claims\Factory
      */
     protected $factory;
 

--- a/tests/Claims/IssuedAtTest.php
+++ b/tests/Claims/IssuedAtTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Claims;
 
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Exceptions\InvalidClaimException;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class IssuedAtTest extends AbstractTestCase
 {

--- a/tests/Claims/NotBeforeTest.php
+++ b/tests/Claims/NotBeforeTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Claims;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Claims;
 
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Exceptions\InvalidClaimException;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class NotBeforeTest extends AbstractTestCase
 {

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -9,36 +9,36 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Custom;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\Factory as ClaimFactory;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Factory;
-use Tymon\JWTAuth\Payload;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Custom;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\Factory as ClaimFactory;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Factory;
+use PHPOpenSourceSaver\JWTAuth\Payload;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class FactoryTest extends AbstractTestCase
 {
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Claims\Factory
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Claims\Factory
      */
     protected $claimFactory;
 
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Validators\PayloadValidator
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator
      */
     protected $validator;
 
     /**
-     * @var \Tymon\JWTAuth\Factory
+     * @var \PHPOpenSourceSaver\JWTAuth\Factory
      */
     protected $factory;
 

--- a/tests/Fixtures/Foo.php
+++ b/tests/Fixtures/Foo.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Fixtures;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Fixtures;
 
-use Tymon\JWTAuth\Claims\Claim;
+use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
 
 class Foo extends Claim
 {

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -9,21 +9,21 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Http;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Http;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Crypt;
 use Mockery;
-use Tymon\JWTAuth\Contracts\Http\Parser as ParserContract;
-use Tymon\JWTAuth\Http\Parser\AuthHeaders;
-use Tymon\JWTAuth\Http\Parser\Cookies;
-use Tymon\JWTAuth\Http\Parser\InputSource;
-use Tymon\JWTAuth\Http\Parser\LumenRouteParams;
-use Tymon\JWTAuth\Http\Parser\Parser;
-use Tymon\JWTAuth\Http\Parser\QueryString;
-use Tymon\JWTAuth\Http\Parser\RouteParams;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser as ParserContract;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\AuthHeaders;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Cookies;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\InputSource;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\LumenRouteParams;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\QueryString;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\RouteParams;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class ParserTest extends AbstractTestCase
 {

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -9,41 +9,41 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Illuminate\Http\Request;
 use Mockery;
 use stdClass;
-use Tymon\JWTAuth\Contracts\Providers\Auth;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Factory;
-use Tymon\JWTAuth\Http\Parser\Parser;
-use Tymon\JWTAuth\JWTAuth;
-use Tymon\JWTAuth\Manager;
-use Tymon\JWTAuth\Payload;
-use Tymon\JWTAuth\Test\Stubs\UserStub;
-use Tymon\JWTAuth\Token;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Factory;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\JWTAuth;
+use PHPOpenSourceSaver\JWTAuth\Manager;
+use PHPOpenSourceSaver\JWTAuth\Payload;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub;
+use PHPOpenSourceSaver\JWTAuth\Token;
 
 class JWTAuthTest extends AbstractTestCase
 {
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Manager
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Manager
      */
     protected $manager;
 
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Contracts\Providers\Auth
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth
      */
     protected $auth;
 
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Http\Parser\Parser
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser
      */
     protected $parser;
 
     /**
-     * @var \Tymon\JWTAuth\JWTAuth
+     * @var \PHPOpenSourceSaver\JWTAuth\JWTAuth
      */
     protected $jwtAuth;
 
@@ -64,7 +64,7 @@ class JWTAuthTest extends AbstractTestCase
         $this->manager
              ->shouldReceive('getPayloadFactory->customClaims')
              ->once()
-             ->with(['sub' => 1, 'prv' => sha1('Tymon\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
+             ->with(['sub' => 1, 'prv' => sha1('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
              ->andReturn($payloadFactory);
 
         $this->manager->shouldReceive('encode->get')->once()->andReturn('foo.bar.baz');
@@ -81,11 +81,11 @@ class JWTAuthTest extends AbstractTestCase
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
         $payloadFactory->shouldReceive('get')
                        ->with('prv')
-                       ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub'));
+                       ->andReturn(sha1('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub'));
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
 
-        $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
+        $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub'));
     }
 
     /** @test */
@@ -99,7 +99,7 @@ class JWTAuthTest extends AbstractTestCase
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
 
-        $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
+        $this->assertTrue($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub'));
     }
 
     /** @test */
@@ -109,11 +109,11 @@ class JWTAuthTest extends AbstractTestCase
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
         $payloadFactory->shouldReceive('get')
                        ->with('prv')
-                       ->andReturn(sha1('Tymon\JWTAuth\Test\Stubs\UserStub1'));
+                       ->andReturn(sha1('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub1'));
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payloadFactory);
 
-        $this->assertFalse($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('Tymon\JWTAuth\Test\Stubs\UserStub'));
+        $this->assertFalse($this->jwtAuth->setToken('foo.bar.baz')->checkSubjectModel('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub'));
     }
 
     /** @test */
@@ -125,7 +125,7 @@ class JWTAuthTest extends AbstractTestCase
         $this->manager
              ->shouldReceive('getPayloadFactory->customClaims')
              ->once()
-             ->with(['sub' => 1, 'prv' => sha1('Tymon\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
+             ->with(['sub' => 1, 'prv' => sha1('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub'), 'foo' => 'bar', 'role' => 'admin'])
              ->andReturn($payloadFactory);
 
         $this->manager->shouldReceive('encode->get')->once()->andReturn('foo.bar.baz');

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -9,23 +9,23 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Http\Request;
 use Mockery;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\UserNotDefinedException;
-use Tymon\JWTAuth\Factory;
-use Tymon\JWTAuth\JWT;
-use Tymon\JWTAuth\JWTGuard;
-use Tymon\JWTAuth\Payload;
-use Tymon\JWTAuth\Test\Stubs\LaravelUserStub;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException;
+use PHPOpenSourceSaver\JWTAuth\Factory;
+use PHPOpenSourceSaver\JWTAuth\JWT;
+use PHPOpenSourceSaver\JWTAuth\JWTGuard;
+use PHPOpenSourceSaver\JWTAuth\Payload;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub;
 
 class JWTGuardTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\JWT|\Mockery\MockInterface
+     * @var \PHPOpenSourceSaver\JWTAuth\JWT|\Mockery\MockInterface
      */
     protected $jwt;
 
@@ -35,7 +35,7 @@ class JWTGuardTest extends AbstractTestCase
     protected $provider;
 
     /**
-     * @var \Tymon\JWTAuth\JWTGuard|\Mockery\MockInterface
+     * @var \PHPOpenSourceSaver\JWTAuth\JWTGuard|\Mockery\MockInterface
      */
     protected $guard;
 
@@ -65,12 +65,12 @@ class JWTGuardTest extends AbstractTestCase
         $this->jwt->shouldReceive('check')->once()->with(true)->andReturn($payload);
         $this->jwt->shouldReceive('checkSubjectModel')
                   ->once()
-                  ->with('\Tymon\JWTAuth\Test\Stubs\LaravelUserStub')
+                  ->with('\PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub')
                   ->andReturn(true);
 
         $this->provider->shouldReceive('getModel')
                        ->once()
-                       ->andReturn('\Tymon\JWTAuth\Test\Stubs\LaravelUserStub');
+                       ->andReturn('\PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub');
         $this->provider->shouldReceive('retrieveById')
                        ->once()
                        ->with(1)
@@ -97,12 +97,12 @@ class JWTGuardTest extends AbstractTestCase
         $this->jwt->shouldReceive('check')->once()->with(true)->andReturn($payload);
         $this->jwt->shouldReceive('checkSubjectModel')
                   ->once()
-                  ->with('\Tymon\JWTAuth\Test\Stubs\LaravelUserStub')
+                  ->with('\PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub')
                   ->andReturn(true);
 
         $this->provider->shouldReceive('getModel')
                        ->once()
-                       ->andReturn('\Tymon\JWTAuth\Test\Stubs\LaravelUserStub');
+                       ->andReturn('\PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub');
         $this->provider->shouldReceive('retrieveById')
              ->once()
              ->with(1)

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -9,45 +9,45 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
-use Tymon\JWTAuth\Blacklist;
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Contracts\Providers\JWT;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenBlacklistedException;
-use Tymon\JWTAuth\Factory;
-use Tymon\JWTAuth\Manager;
-use Tymon\JWTAuth\Payload;
-use Tymon\JWTAuth\Token;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Blacklist;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException;
+use PHPOpenSourceSaver\JWTAuth\Factory;
+use PHPOpenSourceSaver\JWTAuth\Manager;
+use PHPOpenSourceSaver\JWTAuth\Payload;
+use PHPOpenSourceSaver\JWTAuth\Token;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class ManagerTest extends AbstractTestCase
 {
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Contracts\Providers\JWT
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT
      */
     protected $jwt;
 
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Blacklist
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Blacklist
      */
     protected $blacklist;
 
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Factory
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Factory
      */
     protected $factory;
 
     /**
-     * @var \Tymon\JWTAuth\Manager
+     * @var \PHPOpenSourceSaver\JWTAuth\Manager
      */
     protected $manager;
 

--- a/tests/Middleware/AbstractMiddlewareTest.php
+++ b/tests/Middleware/AbstractMiddlewareTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Illuminate\Http\Request;
 use Mockery;
-use Tymon\JWTAuth\JWTAuth;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\JWTAuth;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 abstract class AbstractMiddlewareTest extends AbstractTestCase
 {
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\JWTAuth
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\JWTAuth
      */
     protected $auth;
 

--- a/tests/Middleware/AuthenticateAndRenewTest.php
+++ b/tests/Middleware/AuthenticateAndRenewTest.php
@@ -9,20 +9,20 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Illuminate\Http\Response;
 use Mockery;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Http\Middleware\AuthenticateAndRenew;
-use Tymon\JWTAuth\Http\Parser\Parser;
-use Tymon\JWTAuth\Test\Stubs\UserStub;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\AuthenticateAndRenew;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub;
 
 class AuthenticateAndRenewTest extends AbstractMiddlewareTest
 {
     /**
-     * @var \Tymon\JWTAuth\Http\Middleware\Authenticate|\Tymon\JWTAuth\Http\Middleware\AuthenticateAndRenew
+     * @var \PHPOpenSourceSaver\JWTAuth\Http\Middleware\Authenticate|\PHPOpenSourceSaver\JWTAuth\Http\Middleware\AuthenticateAndRenew
      */
     protected $middleware;
 

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -9,19 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Mockery;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Http\Middleware\Authenticate;
-use Tymon\JWTAuth\Http\Parser\Parser;
-use Tymon\JWTAuth\Test\Stubs\UserStub;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\Authenticate;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub;
 
 class AuthenticateTest extends AbstractMiddlewareTest
 {
     /**
-     * @var \Tymon\JWTAuth\Http\Middleware\Authenticate
+     * @var \PHPOpenSourceSaver\JWTAuth\Http\Middleware\Authenticate
      */
     protected $middleware;
 

--- a/tests/Middleware/CheckTest.php
+++ b/tests/Middleware/CheckTest.php
@@ -9,18 +9,18 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Mockery;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Http\Middleware\Check;
-use Tymon\JWTAuth\Http\Parser\Parser;
-use Tymon\JWTAuth\Test\Stubs\UserStub;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\Check;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub;
 
 class CheckTest extends AbstractMiddlewareTest
 {
     /**
-     * @var \Tymon\JWTAuth\Http\Middleware\Check
+     * @var \PHPOpenSourceSaver\JWTAuth\Http\Middleware\Check
      */
     protected $middleware;
 

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -9,19 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Middleware;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Illuminate\Http\Response;
 use Mockery;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Http\Middleware\RefreshToken;
-use Tymon\JWTAuth\Http\Parser\Parser;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Http\Middleware\RefreshToken;
+use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
 
 class RefreshTokenTest extends AbstractMiddlewareTest
 {
     /**
-     * @var \Tymon\JWTAuth\Http\Middleware\RefreshToken
+     * @var \PHPOpenSourceSaver\JWTAuth\Http\Middleware\RefreshToken
      */
     protected $middleware;
 

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -9,32 +9,32 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use BadMethodCallException;
 use Mockery;
-use Tymon\JWTAuth\Claims\Audience;
-use Tymon\JWTAuth\Claims\Claim;
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Exceptions\PayloadException;
-use Tymon\JWTAuth\Payload;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Claims\Audience;
+use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\PayloadException;
+use PHPOpenSourceSaver\JWTAuth\Payload;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class PayloadTest extends AbstractTestCase
 {
     /**
-     * @var \Mockery\MockInterface|\Tymon\JWTAuth\Validators\PayloadValidator
+     * @var \Mockery\MockInterface|\PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator
      */
     protected $validator;
 
     /**
-     * @var \Tymon\JWTAuth\Payload
+     * @var \PHPOpenSourceSaver\JWTAuth\Payload
      */
     protected $payload;
 
@@ -48,7 +48,7 @@ class PayloadTest extends AbstractTestCase
     /**
      * @param  array  $extraClaims
      *
-     * @return \Tymon\JWTAuth\Payload
+     * @return \PHPOpenSourceSaver\JWTAuth\Payload
      */
     private function getTestPayload(array $extraClaims = [])
     {

--- a/tests/Providers/Auth/IlluminateTest.php
+++ b/tests/Providers/Auth/IlluminateTest.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Providers\Auth;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\Auth;
 
 use Illuminate\Contracts\Auth\Guard;
 use Mockery;
-use Tymon\JWTAuth\Providers\Auth\Illuminate as Auth;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Providers\Auth\Illuminate as Auth;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class IlluminateTest extends AbstractTestCase
 {
@@ -24,7 +24,7 @@ class IlluminateTest extends AbstractTestCase
     protected $authManager;
 
     /**
-     * @var \Tymon\JWTAuth\Providers\Auth\Illuminate
+     * @var \PHPOpenSourceSaver\JWTAuth\Providers\Auth\Illuminate
      */
     protected $auth;
 

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Providers\JWT;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\JWT;
 
 use Exception;
 use InvalidArgumentException;
@@ -17,10 +17,10 @@ use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer\Key;
 use Mockery;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Providers\JWT\Lcobucci;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Lcobucci;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class LcobucciTest extends AbstractTestCase
 {
@@ -35,7 +35,7 @@ class LcobucciTest extends AbstractTestCase
     protected $builder;
 
     /**
-     * @var \Tymon\JWTAuth\Providers\JWT\Namshi
+     * @var \PHPOpenSourceSaver\JWTAuth\Providers\JWT\Namshi
      */
     protected $provider;
 

--- a/tests/Providers/JWT/NamshiTest.php
+++ b/tests/Providers/JWT/NamshiTest.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Providers\JWT;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\JWT;
 
 use Exception;
 use InvalidArgumentException;
 use Mockery;
 use Namshi\JOSE\JWS;
-use Tymon\JWTAuth\Exceptions\JWTException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Providers\JWT\Namshi;
-use Tymon\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Namshi;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class NamshiTest extends AbstractTestCase
 {
@@ -28,7 +28,7 @@ class NamshiTest extends AbstractTestCase
     protected $jws;
 
     /**
-     * @var \Tymon\JWTAuth\Providers\JWT\Namshi
+     * @var \PHPOpenSourceSaver\JWTAuth\Providers\JWT\Namshi
      */
     protected $provider;
 

--- a/tests/Providers/JWT/ProviderTest.php
+++ b/tests/Providers/JWT/ProviderTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Providers\JWT;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\JWT;
 
-use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Test\Stubs\JWTProviderStub;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\JWTProviderStub;
 
 class ProviderTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\Test\Stubs\JWTProviderStub
+     * @var \PHPOpenSourceSaver\JWTAuth\Test\Stubs\JWTProviderStub
      */
     protected $provider;
 

--- a/tests/Providers/Storage/IlluminateTest.php
+++ b/tests/Providers/Storage/IlluminateTest.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Providers\Storage;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\Storage;
 
 use Illuminate\Contracts\Cache\Repository;
 use Mockery;
-use Tymon\JWTAuth\Providers\Storage\Illuminate as Storage;
-use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Test\Stubs\TaggedStorage;
+use PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate as Storage;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\TaggedStorage;
 
 class IlluminateTest extends AbstractTestCase
 {
@@ -25,7 +25,7 @@ class IlluminateTest extends AbstractTestCase
     protected $cache;
 
     /**
-     * @var \Tymon\JWTAuth\Providers\Storage\Illuminate
+     * @var \PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate
      */
     protected $storage;
 

--- a/tests/Stubs/JWTProviderStub.php
+++ b/tests/Stubs/JWTProviderStub.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Stubs;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Stubs;
 
-use Tymon\JWTAuth\Providers\JWT\Provider;
+use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Provider;
 
 class JWTProviderStub extends Provider
 {

--- a/tests/Stubs/LaravelUserStub.php
+++ b/tests/Stubs/LaravelUserStub.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Stubs;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Stubs;
 
 use Illuminate\Contracts\Auth\Authenticatable;
-use Tymon\JWTAuth\Contracts\JWTSubject;
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
 
 class LaravelUserStub extends UserStub implements Authenticatable, JWTSubject
 {

--- a/tests/Stubs/TaggedStorage.php
+++ b/tests/Stubs/TaggedStorage.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Stubs;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Stubs;
 
-use Tymon\JWTAuth\Providers\Storage\Illuminate as Storage;
+use PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate as Storage;
 
 class TaggedStorage extends Storage
 {

--- a/tests/Stubs/UserStub.php
+++ b/tests/Stubs/UserStub.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Stubs;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Stubs;
 
-use Tymon\JWTAuth\Contracts\JWTSubject;
+use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
 
 class UserStub implements JWTSubject
 {

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test;
+namespace PHPOpenSourceSaver\JWTAuth\Test;
 
-use Tymon\JWTAuth\Token;
+use PHPOpenSourceSaver\JWTAuth\Token;
 
 class TokenTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\Token
+     * @var \PHPOpenSourceSaver\JWTAuth\Token
      */
     protected $token;
 

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -9,25 +9,25 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Validators;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Validators;
 
-use Tymon\JWTAuth\Claims\Collection;
-use Tymon\JWTAuth\Claims\Expiration;
-use Tymon\JWTAuth\Claims\IssuedAt;
-use Tymon\JWTAuth\Claims\Issuer;
-use Tymon\JWTAuth\Claims\JwtId;
-use Tymon\JWTAuth\Claims\NotBefore;
-use Tymon\JWTAuth\Claims\Subject;
-use Tymon\JWTAuth\Exceptions\InvalidClaimException;
-use Tymon\JWTAuth\Exceptions\TokenExpiredException;
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Validators\PayloadValidator;
+use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
+use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
+use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
+use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
+use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
+use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
+use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class PayloadValidatorTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\Validators\PayloadValidator
+     * @var \PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator
      */
     protected $validator;
 

--- a/tests/Validators/TokenValidatorTest.php
+++ b/tests/Validators/TokenValidatorTest.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Tymon\JWTAuth\Test\Validators;
+namespace PHPOpenSourceSaver\JWTAuth\Test\Validators;
 
-use Tymon\JWTAuth\Exceptions\TokenInvalidException;
-use Tymon\JWTAuth\Test\AbstractTestCase;
-use Tymon\JWTAuth\Validators\TokenValidator;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Validators\TokenValidator;
 
 class TokenValidatorTest extends AbstractTestCase
 {
     /**
-     * @var \Tymon\JWTAuth\Validators\TokenValidator
+     * @var \PHPOpenSourceSaver\JWTAuth\Validators\TokenValidator
      */
     protected $validator;
 
@@ -37,7 +37,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
-     * @dataProvider \Tymon\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderMalformedTokens
+     * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderMalformedTokens
      *
      * @param  string  $token
      */
@@ -48,7 +48,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
-     * @dataProvider \Tymon\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderMalformedTokens
+     * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderMalformedTokens
      */
     public function it_should_throw_an_exception_when_providing_a_malformed_token($token)
     {
@@ -60,7 +60,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
-     * @dataProvider \Tymon\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
+     * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
      */
     public function it_should_return_false_when_providing_a_token_with_wrong_segments_number($token)
     {
@@ -69,7 +69,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
-     * @dataProvider \Tymon\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
+     * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
      */
     public function it_should_throw_an_exception_when_providing_a_malformed_token_with_wrong_segments_number($token)
     {


### PR DESCRIPTION
I have changed the PHP namespace to PHPOpenSourceSaver. The composer package name has been renamed to `php-open-source-saver/jwt-auth`.

Additionaly the patreon account has been removed. 

#3 