### PR TITLE
fix instantiation of lcobucci/jwt ECDSA signers

### DIFF
--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -230,7 +230,13 @@ class Lcobucci extends Provider implements JWT
             throw new JWTException('The given algorithm could not be found');
         }
 
-        return new $this->signers[$this->algo];
+        $signer = $this->signers[$this->algo];
+
+        if (is_subclass_of($signer, 'Lcobucci\JWT\Signer\Ecdsa')) {
+            return $signer::create();
+        }
+
+        return new $signer;
     }
 
     /**

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -232,7 +232,7 @@ class Lcobucci extends Provider implements JWT
 
         $signer = $this->signers[$this->algo];
 
-        if (is_subclass_of($signer, 'Lcobucci\JWT\Signer\Ecdsa')) {
+        if (is_subclass_of($signer, Ecdsa::class)) {
             return $signer::create();
         }
 

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -222,6 +222,18 @@ class LcobucciTest extends AbstractTestCase
         $this->assertSame($keys, $provider->getKeys());
     }
 
+    /** @test */
+    public function it_should_correctly_instantiate_an_ecdsa_signer()
+    {
+        $provider = new Lcobucci(
+            'does_not_matter',
+            'ES256',
+            ['private' => 'dummy', 'public' => 'dummy']
+        );
+
+        $this->assertSame('ES256', $provider->getConfig()->signer()->algorithmId());
+    }
+
     public function getProvider($secret, $algo, array $keys = [])
     {
         $provider = new Lcobucci($secret, $algo, $keys);


### PR DESCRIPTION
In the package `lcobucci/jwt`, the signers [HMAC](https://github.com/lcobucci/jwt/blob/fe9b26333c661aee9cebc251fcaf0949b03d7fdb/src/Signer/Hmac.php#L11) and [RSA](https://github.com/lcobucci/jwt/blob/fe9b26333c661aee9cebc251fcaf0949b03d7fdb/src/Signer/Rsa.php#L8) signers have no constructor. So, this code is fine for them:
```php 
return new $this->signers[$this->algo];
```

But, the signers which extends `Lcobucci\JWT\Signer\Ecdsa` class have [a construct signature with one argument](https://github.com/lcobucci/jwt/blob/fe9b26333c661aee9cebc251fcaf0949b03d7fdb/src/Signer/Ecdsa.php#L15
).

This pull request fixes the instantiation of them.