### PR TITLE
Add php-cs-fixer with PSR12 as baseline + github workflow to auto-fix the code style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /.github export-ignore
+/.php-cs-fixer.dist.php export-ignore
 /phpunit.xml.dist export-ignore
 /README.md export-ignore
 /mkdocs.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.styleci.yml export-ignore
 /.travis.yml export-ignore
 /.github export-ignore
 /phpunit.xml.dist export-ignore

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,33 @@
+name: PHP-CS-Fixer
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  php-cs-fixer:
+    name: Fix Code Style
+    timeout-minutes: 5
+    runs-on: ubuntu-20.04
+    env:
+      COMPOSER_NO_INTERACTION: 1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --no-plugins --no-scripts
+
+      - run: composer php-cs-fixer
+        continue-on-error: true
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: composer php-cs-fixer

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 coverage.xml
 .phpunit.result.cache
 .idea
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+use PhpCsFixer\Config;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__);
+
+return (new Config())
+    ->setFinder($finder)
+    ->setRules([
+        '@PSR12' => true,
+    ]);

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,8 +1,0 @@
-preset: laravel
-
-enabled:
-  - no_useless_else
-  - phpdoc_order
-  - phpdoc_separation
-  - unalign_double_arrow
-  # - length_ordered_imports

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "ext-json": "*"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3",
         "illuminate/console": "^5.2|^6|^7|^8",
         "illuminate/routing": "^5.2|^6|^7|^8",
         "mockery/mockery": ">=0.9.9",

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "scripts": {
+        "php-cs-fixer": "php-cs-fixer fix --diff",
         "test": "phpunit --colors=always",
         "test:ci": "composer test -- --verbose --coverage-text --coverage-clover=coverage.xml"
     }

--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -71,7 +71,8 @@ class JWTGenerateSecretCommand extends Command
             // update existing entry
             file_put_contents($path, str_replace(
                 'JWT_SECRET='.$this->laravel['config']['jwt.secret'],
-                'JWT_SECRET='.$key, file_get_contents($path)
+                'JWT_SECRET='.$key,
+                file_get_contents($path)
             ));
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -20,7 +20,8 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class Factory
 {
-    use CustomClaims, RefreshFlow;
+    use CustomClaims;
+    use RefreshFlow;
 
     /**
      * The claim factory.
@@ -68,7 +69,7 @@ class Factory
     {
         $this->claimFactory = $claimFactory;
         $this->validator = $validator;
-        $this->claims = new Collection;
+        $this->claims = new Collection();
     }
 
     /**
@@ -94,7 +95,7 @@ class Factory
      */
     public function emptyClaims()
     {
-        $this->claims = new Collection;
+        $this->claims = new Collection();
 
         return $this;
     }

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -114,7 +114,7 @@ class JWTGuard implements Guard
     public function userOrFail()
     {
         if (!$user = $this->user()) {
-            throw new UserNotDefinedException;
+            throw new UserNotDefinedException();
         }
 
         return $user;

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -19,7 +19,8 @@ use PHPOpenSourceSaver\JWTAuth\Support\RefreshFlow;
 
 class Manager
 {
-    use CustomClaims, RefreshFlow;
+    use CustomClaims;
+    use RefreshFlow;
 
     /**
      * The provider.

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -228,9 +228,9 @@ abstract class AbstractServiceProvider extends ServiceProvider
             $parser = new Parser(
                 $app['request'],
                 [
-                    new AuthHeaders,
-                    new QueryString,
-                    new InputSource,
+                    new AuthHeaders(),
+                    new QueryString(),
+                    new InputSource(),
                 ]
             );
 
@@ -294,7 +294,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     protected function registerPayloadValidator()
     {
         $this->app->singleton('tymon.jwt.validators.payload', function () {
-            return (new PayloadValidator)
+            return (new PayloadValidator())
                 ->setRefreshTTL($this->config('refresh_ttl'))
                 ->setRequiredClaims($this->config('required_claims'));
         });
@@ -339,7 +339,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     protected function registerJWTCommand()
     {
         $this->app->singleton('tymon.jwt.secret', function () {
-            return new JWTGenerateSecretCommand;
+            return new JWTGenerateSecretCommand();
         });
     }
 

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -75,8 +75,7 @@ class Lcobucci extends Provider implements JWT
         $algo,
         array $keys,
         $config = null
-    )
-    {
+    ) {
         parent::__construct($secret, $algo, $keys);
 
         $this->signer = $this->getSigner();
@@ -238,7 +237,7 @@ class Lcobucci extends Provider implements JWT
             return $signer::create();
         }
 
-        return new $signer;
+        return new $signer();
     }
 
     /**

--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -31,7 +31,7 @@ class LaravelServiceProvider extends AbstractServiceProvider
         $this->extendAuthGuard();
 
         $this->app['tymon.jwt.parser']->addParser([
-            new RouteParams,
+            new RouteParams(),
             new Cookies($this->config('decrypt_cookies')),
         ]);
     }

--- a/src/Providers/LumenServiceProvider.php
+++ b/src/Providers/LumenServiceProvider.php
@@ -29,6 +29,6 @@ class LumenServiceProvider extends AbstractServiceProvider
 
         $this->extendAuthGuard();
 
-        $this->app['tymon.jwt.parser']->addParser(new LumenRouteParams);
+        $this->app['tymon.jwt.parser']->addParser(new LumenRouteParams());
     }
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -30,7 +30,7 @@ class Token
      */
     public function __construct($value)
     {
-        $this->value = (string)(new TokenValidator)->check($value);
+        $this->value = (string)(new TokenValidator())->check($value);
     }
 
     /**

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -38,10 +38,10 @@ class ParserTest extends AbstractTestCase
         $parser = new Parser($request);
 
         $parser->setChain([
-            new QueryString,
-            new InputSource,
-            new AuthHeaders,
-            new RouteParams,
+            new QueryString(),
+            new InputSource(),
+            new AuthHeaders(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -57,10 +57,10 @@ class ParserTest extends AbstractTestCase
         $parser = new Parser($request);
 
         $parser->setChain([
-            new QueryString,
-            new InputSource,
-            (new AuthHeaders)->setHeaderPrefix('Custom'),
-            new RouteParams,
+            new QueryString(),
+            new InputSource(),
+            (new AuthHeaders())->setHeaderPrefix('Custom'),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -76,10 +76,10 @@ class ParserTest extends AbstractTestCase
         $parser = new Parser($request);
 
         $parser->setChain([
-            new QueryString,
-            new InputSource,
-            (new AuthHeaders)->setHeaderName('custom_authorization'),
-            new RouteParams,
+            new QueryString(),
+            new InputSource(),
+            (new AuthHeaders())->setHeaderName('custom_authorization'),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -96,10 +96,10 @@ class ParserTest extends AbstractTestCase
         $request2->server->set('REDIRECT_HTTP_AUTHORIZATION', 'Bearer foobarbaz');
 
         $parser = new Parser($request1, [
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -119,10 +119,10 @@ class ParserTest extends AbstractTestCase
         $parser = new Parser($request);
 
         $parser->setChain([
-            new QueryString,
-            new InputSource,
-            new AuthHeaders,
-            new RouteParams,
+            new QueryString(),
+            new InputSource(),
+            new AuthHeaders(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar--');
@@ -141,10 +141,10 @@ class ParserTest extends AbstractTestCase
         $parser = new Parser($request);
 
         $parser->setChain([
-            new QueryString,
-            new InputSource,
-            new AuthHeaders,
-            new RouteParams,
+            new QueryString(),
+            new InputSource(),
+            new AuthHeaders(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -173,10 +173,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -190,10 +190,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            (new QueryString)->setKey('custom_token_key'),
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            (new QueryString())->setKey('custom_token_key'),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -207,10 +207,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -224,10 +224,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            (new QueryString)->setKey('custom_token_key'),
-            (new InputSource)->setKey('custom_token_key'),
-            new RouteParams,
+            new AuthHeaders(),
+            (new QueryString())->setKey('custom_token_key'),
+            (new InputSource())->setKey('custom_token_key'),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -242,10 +242,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -260,10 +260,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            (new InputSource)->setKey('custom_token_key'),
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            (new InputSource())->setKey('custom_token_key'),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -277,10 +277,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
             new Cookies(false),
         ]);
 
@@ -300,10 +300,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
             new Cookies(true),
         ]);
 
@@ -323,10 +323,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
             new Cookies(true),
         ]);
 
@@ -349,10 +349,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -378,10 +378,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            (new RouteParams)->setKey('custom_route_param'),
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            (new RouteParams())->setKey('custom_route_param'),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foobar');
@@ -398,10 +398,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertNull($parser->parseToken());
@@ -418,10 +418,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertNull($parser->parseToken());
@@ -438,10 +438,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new LumenRouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new LumenRouteParams(),
         ]);
 
         $this->assertSame($parser->parseToken(), 'foo.bar.baz');
@@ -458,10 +458,10 @@ class ParserTest extends AbstractTestCase
 
         $parser = new Parser($request);
         $parser->setChain([
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ]);
 
         $this->assertNull($parser->parseToken());
@@ -472,10 +472,10 @@ class ParserTest extends AbstractTestCase
     public function it_should_retrieve_the_chain()
     {
         $chain = [
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ];
 
         $parser = new Parser(Mockery::mock(Request::class));
@@ -488,10 +488,10 @@ class ParserTest extends AbstractTestCase
     public function it_should_retrieve_the_chain_with_alias()
     {
         $chain = [
-            new AuthHeaders,
-            new QueryString,
-            new InputSource,
-            new RouteParams,
+            new AuthHeaders(),
+            new QueryString(),
+            new InputSource(),
+            new RouteParams(),
         ];
 
         /* @var Request $request */
@@ -506,7 +506,7 @@ class ParserTest extends AbstractTestCase
     /** @test */
     public function it_should_set_the_cookie_key()
     {
-        $cookies = (new Cookies)->setKey('test');
+        $cookies = (new Cookies())->setKey('test');
         $this->assertInstanceOf(Cookies::class, $cookies);
     }
 

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -70,7 +70,7 @@ class JWTAuthTest extends AbstractTestCase
 
         $this->manager->shouldReceive('encode->get')->once()->andReturn('foo.bar.baz');
 
-        $token = $this->jwtAuth->fromUser(new UserStub);
+        $token = $this->jwtAuth->fromUser(new UserStub());
 
         $this->assertSame($token, 'foo.bar.baz');
     }
@@ -132,7 +132,7 @@ class JWTAuthTest extends AbstractTestCase
         $this->manager->shouldReceive('encode->get')->once()->andReturn('foo.bar.baz');
 
         $this->auth->shouldReceive('byCredentials')->once()->andReturn(true);
-        $this->auth->shouldReceive('user')->once()->andReturn(new UserStub);
+        $this->auth->shouldReceive('user')->once()->andReturn(new UserStub());
 
         $token = $this->jwtAuth->attempt(['foo' => 'bar']);
 
@@ -245,7 +245,7 @@ class JWTAuthTest extends AbstractTestCase
     public function it_should_return_false_if_the_token_is_invalid()
     {
         $this->parser->shouldReceive('parseToken')->andReturn('foo.bar.baz');
-        $this->manager->shouldReceive('decode')->once()->andThrow(new TokenInvalidException);
+        $this->manager->shouldReceive('decode')->once()->andThrow(new TokenInvalidException());
 
         $this->assertFalse($this->jwtAuth->parseToken()->check());
     }
@@ -283,7 +283,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_magically_call_the_manager()
     {
-        $this->manager->shouldReceive('getBlacklist')->andReturn(new stdClass);
+        $this->manager->shouldReceive('getBlacklist')->andReturn(new stdClass());
 
         $blacklist = $this->jwtAuth->manager()->getBlacklist();
 
@@ -306,7 +306,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function it_should_unset_the_token()
     {
-        $this->parser->shouldReceive('parseToken')->andThrow(new JWTException);
+        $this->parser->shouldReceive('parseToken')->andThrow(new JWTException());
         $token = new Token('foo.bar.baz');
         $this->jwtAuth->setToken($token);
 

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -194,7 +194,7 @@ class JWTGuardTest extends AbstractTestCase
     public function it_should_return_a_token_if_credentials_are_ok_and_user_is_found()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->provider->shouldReceive('retrieveByCredentials')
             ->once()
@@ -239,7 +239,7 @@ class JWTGuardTest extends AbstractTestCase
     public function it_should_return_true_if_credentials_are_ok_and_user_is_found_when_choosing_not_to_login()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->provider->shouldReceive('retrieveByCredentials')
             ->twice()
@@ -267,7 +267,7 @@ class JWTGuardTest extends AbstractTestCase
     public function it_should_return_false_if_credentials_are_invalid()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->provider->shouldReceive('retrieveByCredentials')
             ->once()
@@ -345,7 +345,7 @@ class JWTGuardTest extends AbstractTestCase
     /** @test */
     public function it_should_generate_a_token_by_id()
     {
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->provider->shouldReceive('retrieveById')
             ->once()
@@ -375,7 +375,7 @@ class JWTGuardTest extends AbstractTestCase
     public function it_should_authenticate_the_user_by_credentials_and_return_true_if_valid()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->provider->shouldReceive('retrieveByCredentials')
             ->once()
@@ -402,7 +402,7 @@ class JWTGuardTest extends AbstractTestCase
     public function it_should_attempt_to_authenticate_the_user_by_credentials_and_return_false_if_invalid()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->provider->shouldReceive('retrieveByCredentials')
             ->once()
@@ -428,7 +428,7 @@ class JWTGuardTest extends AbstractTestCase
     /** @test */
     public function it_should_authenticate_the_user_by_id_and_return_boolean()
     {
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->provider->shouldReceive('retrieveById')
             ->twice()
@@ -454,7 +454,7 @@ class JWTGuardTest extends AbstractTestCase
     /** @test */
     public function it_should_create_a_token_from_a_user_object()
     {
-        $user = new LaravelUserStub;
+        $user = new LaravelUserStub();
 
         $this->jwt->shouldReceive('fromUser')
             ->once()

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -278,27 +278,27 @@ class ManagerTest extends AbstractTestCase
         $this->assertInstanceOf(Blacklist::class, $this->manager->getBlacklist());
     }
 
-     /** @test */
-     public function test_if_show_blacklisted_exception_configuration_is_enabled()
-     {
-         $this->manager->setBlackListExceptionEnabled(true);
- 
-         $this->assertIsBool($this->manager->getBlackListExceptionEnabled());
-     }
- 
-     /** @test */
-     public function test_if_black_listed_exception_is_set_to_true()
-     {
-         $this->manager->setBlackListExceptionEnabled(true);
- 
-         $this->assertTrue($this->manager->getBlackListExceptionEnabled());
-     }
- 
-     /** @test */
-     public function test_if_black_listed_exception_is_set_to_false()
-     {
-         $this->manager->setBlackListExceptionEnabled(false);
- 
-         $this->assertFalse($this->manager->getBlackListExceptionEnabled());
-     }
+    /** @test */
+    public function test_if_show_blacklisted_exception_configuration_is_enabled()
+    {
+        $this->manager->setBlackListExceptionEnabled(true);
+
+        $this->assertIsBool($this->manager->getBlackListExceptionEnabled());
+    }
+
+    /** @test */
+    public function test_if_black_listed_exception_is_set_to_true()
+    {
+        $this->manager->setBlackListExceptionEnabled(true);
+
+        $this->assertTrue($this->manager->getBlackListExceptionEnabled());
+    }
+
+    /** @test */
+    public function test_if_black_listed_exception_is_set_to_false()
+    {
+        $this->manager->setBlackListExceptionEnabled(false);
+
+        $this->assertFalse($this->manager->getBlackListExceptionEnabled());
+    }
 }

--- a/tests/Middleware/AuthenticateAndRenewTest.php
+++ b/tests/Middleware/AuthenticateAndRenewTest.php
@@ -42,12 +42,12 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parser')->andReturn($parser);
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
 
-        $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub);
+        $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub());
 
         $this->auth->shouldReceive('refresh')->once()->andReturn('foo.bar.baz');
 
         $response = $this->middleware->handle($this->request, function () {
-            return new Response;
+            return new Response();
         });
 
         $this->assertSame($response->headers->get('authorization'), 'Bearer foo.bar.baz');
@@ -80,7 +80,7 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
-        $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException);
+        $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
             //

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -41,7 +41,7 @@ class AuthenticateTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
-        $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub);
+        $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub());
 
         $this->middleware->handle($this->request, function () {
             //
@@ -75,7 +75,7 @@ class AuthenticateTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
-        $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException);
+        $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
             //

--- a/tests/Middleware/CheckTest.php
+++ b/tests/Middleware/CheckTest.php
@@ -40,7 +40,7 @@ class CheckTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
-        $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub);
+        $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub());
 
         $this->middleware->handle($this->request, function () {
             //
@@ -56,7 +56,7 @@ class CheckTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
-        $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException);
+        $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
             //

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -44,7 +44,7 @@ class RefreshTokenTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->refresh')->once()->andReturn('foo.bar.baz');
 
         $response = $this->middleware->handle($this->request, function () {
-            return new Response;
+            return new Response();
         });
 
         $this->assertSame($response->headers->get('authorization'), 'Bearer foo.bar.baz');
@@ -77,7 +77,7 @@ class RefreshTokenTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parser')->andReturn($parser);
 
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
-        $this->auth->shouldReceive('parseToken->refresh')->once()->andThrow(new TokenInvalidException);
+        $this->auth->shouldReceive('parseToken->refresh')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
             //

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -100,7 +100,7 @@ class LcobucciTest extends AbstractTestCase
             ->shouldReceive('getToken')
             ->once()
             ->with(\Mockery::type(Signer::class), \Mockery::type(Key::class))
-            ->andThrow(new Exception);
+            ->andThrow(new Exception());
 
         $this->getProvider('secret', 'HS256')->encode($payload);
     }
@@ -148,7 +148,7 @@ class LcobucciTest extends AbstractTestCase
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Could not decode token:');
 
-        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andThrow(new InvalidArgumentException);
+        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andThrow(new InvalidArgumentException());
         $this->parser->shouldReceive('verify')->never();
         $this->parser->shouldReceive('getClaims')->never();
 

--- a/tests/Providers/JWT/NamshiTest.php
+++ b/tests/Providers/JWT/NamshiTest.php
@@ -68,7 +68,7 @@ class NamshiTest extends AbstractTestCase
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
         $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(Mockery::self());
-        $this->jws->shouldReceive('sign')->andThrow(new Exception);
+        $this->jws->shouldReceive('sign')->andThrow(new Exception());
 
         $this->getProvider('secret', 'HS256')->encode($payload);
     }
@@ -104,7 +104,7 @@ class NamshiTest extends AbstractTestCase
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Could not decode token:');
 
-        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andThrow(new InvalidArgumentException);
+        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andThrow(new InvalidArgumentException());
         $this->jws->shouldReceive('verify')->never();
         $this->jws->shouldReceive('getPayload')->never();
 

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -35,7 +35,7 @@ class PayloadValidatorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->validator = new PayloadValidator;
+        $this->validator = new PayloadValidator();
     }
 
     /** @test */

--- a/tests/Validators/TokenValidatorTest.php
+++ b/tests/Validators/TokenValidatorTest.php
@@ -26,7 +26,7 @@ class TokenValidatorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->validator = new TokenValidator;
+        $this->validator = new TokenValidator();
     }
 
     /** @test */


### PR DESCRIPTION
_Before you see the diff and collapse from your chair, hear me out 👂🏼_

## Summary
The original forked seems to have used styleci but it's not even enabled in this fork, essentially having no code style check in place right now.

This PR:
- removes styleci references entirely 🏌🏼‍♀️ 
- adds php-cs-fixer as dev dependency
- with a `@PSR12` baseline config (so: nothing fancy)
- a composer script so one can run `composer php-cs-fixer` anytime and it will **fix the code**
- adds a github workflow which runs the fixer and commit back any pending changes, saving developers time 🎉 
  ![image](https://user-images.githubusercontent.com/87493/141200689-13e89725-fe6b-45fd-bc4f-90520a8828cf.png)


The PR is so "big" because it already shows the successful run of the github workflow in my fork => https://github.com/mfn/jwt-auth/runs/4171305036?check_suite_focus=true

It's also clean/separate commits for individual review

### Why
I think code style standards are important but should not get into your way (i.e. avoid even having to discuss benign things in PR, like my feedback in https://github.com/PHP-Open-Source-Saver/jwt-auth/pull/45#discussion_r746927826


Thank you 🙏🏼 