### PR TITLE
Update minimal PHP version to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.4|^8.0",
         "illuminate/auth": "^6|^7|^8",
         "illuminate/contracts": "^6|^7|^8",
         "illuminate/database": "^6.20.26|^7.30.4|^8.40.0",

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
+        "ext-json": "*",
         "illuminate/auth": "^6|^7|^8",
         "illuminate/contracts": "^6|^7|^8",
         "illuminate/database": "^6.20.26|^7.30.4|^8.40.0",
@@ -41,8 +42,7 @@
         "illuminate/support": "^6|^7|^8",
         "lcobucci/jwt": "^4.0",
         "namshi/jose": "^7.0",
-        "nesbot/carbon": "^1.0|^2.0",
-        "ext-json": "*"
+        "nesbot/carbon": "^1.0|^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
@@ -50,8 +50,9 @@
         "illuminate/routing": "^6|^7|^8",
         "mockery/mockery": ">=0.9.9",
         "phpunit/phpunit": "^8.5|^9.4",
-        "yoast/phpunit-polyfills": "^1.0.2",
-        "vlucas/phpdotenv": "^5.2.0"
+        "rector/rector": "^0.12.4",
+        "vlucas/phpdotenv": "^5.2.0",
+        "yoast/phpunit-polyfills": "^1.0.2"
     },
     "autoload": {
         "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/tests'
+    ]);
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
+
+    // Define what rule sets will be applied
+    $containerConfigurator->import(SetList::PHP_74);
+
+    // get services (needed for register a single rule)
+    // $services = $containerConfigurator->services();
+
+    // register a single rule
+    // $services->set(TypedPropertyRector::class);
+};

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
-use Rector\Php74\Rector\Property\TypedPropertyRector;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -24,10 +24,8 @@ abstract class BaseMiddleware
 {
     /**
      * The JWT Authenticator.
-     *
-     * @var JWTAuth
      */
-    protected $auth;
+    protected \PHPOpenSourceSaver\JWTAuth\JWTAuth $auth;
 
     /**
      * Create a new BaseMiddleware instance.

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -25,7 +25,7 @@ abstract class BaseMiddleware
     /**
      * The JWT Authenticator.
      */
-    protected \PHPOpenSourceSaver\JWTAuth\JWTAuth $auth;
+    protected JWTAuth $auth;
 
     /**
      * Create a new BaseMiddleware instance.

--- a/src/Http/Parser/Parser.php
+++ b/src/Http/Parser/Parser.php
@@ -23,7 +23,7 @@ class Parser
     /**
      * The request.
      */
-    protected \Illuminate\Http\Request $request;
+    protected Request $request;
 
     /**
      * Constructor.

--- a/src/Http/Parser/Parser.php
+++ b/src/Http/Parser/Parser.php
@@ -17,17 +17,13 @@ class Parser
 {
     /**
      * The chain.
-     *
-     * @var array
      */
-    private $chain;
+    private array $chain;
 
     /**
      * The request.
-     *
-     * @var Request
      */
-    protected $request;
+    protected \Illuminate\Http\Request $request;
 
     /**
      * Constructor.

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -15,7 +15,6 @@ use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
 use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
 
-/** @deprecated */
 class JWTAuth extends JWT
 {
     /**

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -40,10 +40,8 @@ abstract class AbstractServiceProvider extends ServiceProvider
 {
     /**
      * The middleware aliases.
-     *
-     * @var array
      */
-    protected $middlewareAliases = [
+    protected array $middlewareAliases = [
         'jwt.auth' => Authenticate::class,
         'jwt.check' => Check::class,
         'jwt.refresh' => RefreshToken::class,
@@ -135,9 +133,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
         $this->registerNamshiProvider();
         $this->registerLcobucciProvider();
 
-        $this->app->singleton('tymon.jwt.provider.jwt', function ($app) {
-            return $this->getConfigInstance('providers.jwt');
-        });
+        $this->app->singleton('tymon.jwt.provider.jwt', fn($app) => $this->getConfigInstance('providers.jwt'));
     }
 
     /**
@@ -147,14 +143,12 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerNamshiProvider()
     {
-        $this->app->singleton('tymon.jwt.provider.jwt.namshi', function ($app) {
-            return new Namshi(
-                new JWS(['typ' => 'JWT', 'alg' => $this->config('algo')]),
-                $this->config('secret'),
-                $this->config('algo'),
-                $this->config('keys')
-            );
-        });
+        $this->app->singleton('tymon.jwt.provider.jwt.namshi', fn($app) => new Namshi(
+            new JWS(['typ' => 'JWT', 'alg' => $this->config('algo')]),
+            $this->config('secret'),
+            $this->config('algo'),
+            $this->config('keys')
+        ));
     }
 
     /**
@@ -164,13 +158,11 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerLcobucciProvider()
     {
-        $this->app->singleton('tymon.jwt.provider.jwt.lcobucci', function ($app) {
-            return new Lcobucci(
-                $this->config('secret'),
-                $this->config('algo'),
-                $this->config('keys')
-            );
-        });
+        $this->app->singleton('tymon.jwt.provider.jwt.lcobucci', fn($app) => new Lcobucci(
+            $this->config('secret'),
+            $this->config('algo'),
+            $this->config('keys')
+        ));
     }
 
     /**
@@ -180,9 +172,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerAuthProvider()
     {
-        $this->app->singleton('tymon.jwt.provider.auth', function () {
-            return $this->getConfigInstance('providers.auth');
-        });
+        $this->app->singleton('tymon.jwt.provider.auth', fn() => $this->getConfigInstance('providers.auth'));
     }
 
     /**
@@ -192,9 +182,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerStorageProvider()
     {
-        $this->app->singleton('tymon.jwt.provider.storage', function () {
-            return $this->getConfigInstance('providers.storage');
-        });
+        $this->app->singleton('tymon.jwt.provider.storage', fn() => $this->getConfigInstance('providers.storage'));
     }
 
     /**
@@ -247,12 +235,10 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerJWT()
     {
-        $this->app->singleton('tymon.jwt', function ($app) {
-            return (new JWT(
-                $app['tymon.jwt.manager'],
-                $app['tymon.jwt.parser']
-            ))->lockSubject($this->config('lock_subject'));
-        });
+        $this->app->singleton('tymon.jwt', fn($app) => (new JWT(
+            $app['tymon.jwt.manager'],
+            $app['tymon.jwt.parser']
+        ))->lockSubject($this->config('lock_subject')));
     }
 
     /**
@@ -262,13 +248,11 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerJWTAuth()
     {
-        $this->app->singleton('tymon.jwt.auth', function ($app) {
-            return (new JWTAuth(
-                $app['tymon.jwt.manager'],
-                $app['tymon.jwt.provider.auth'],
-                $app['tymon.jwt.parser']
-            ))->lockSubject($this->config('lock_subject'));
-        });
+        $this->app->singleton('tymon.jwt.auth', fn($app) => (new JWTAuth(
+            $app['tymon.jwt.manager'],
+            $app['tymon.jwt.provider.auth'],
+            $app['tymon.jwt.parser']
+        ))->lockSubject($this->config('lock_subject')));
     }
 
     /**
@@ -293,11 +277,9 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerPayloadValidator()
     {
-        $this->app->singleton('tymon.jwt.validators.payload', function () {
-            return (new PayloadValidator())
-                ->setRefreshTTL($this->config('refresh_ttl'))
-                ->setRequiredClaims($this->config('required_claims'));
-        });
+        $this->app->singleton('tymon.jwt.validators.payload', fn() => (new PayloadValidator())
+            ->setRefreshTTL($this->config('refresh_ttl'))
+            ->setRequiredClaims($this->config('required_claims')));
     }
 
     /**
@@ -323,12 +305,10 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerPayloadFactory()
     {
-        $this->app->singleton('tymon.jwt.payload.factory', function ($app) {
-            return new Factory(
-                $app['tymon.jwt.claim.factory'],
-                $app['tymon.jwt.validators.payload']
-            );
-        });
+        $this->app->singleton('tymon.jwt.payload.factory', fn($app) => new Factory(
+            $app['tymon.jwt.claim.factory'],
+            $app['tymon.jwt.validators.payload']
+        ));
     }
 
     /**
@@ -338,9 +318,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     protected function registerJWTCommand()
     {
-        $this->app->singleton('tymon.jwt.secret', function () {
-            return new JWTGenerateSecretCommand();
-        });
+        $this->app->singleton('tymon.jwt.secret', fn() => new JWTGenerateSecretCommand());
     }
 
     /**

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -18,24 +18,18 @@ abstract class Provider
 {
     /**
      * The secret.
-     *
-     * @var string
      */
-    protected $secret;
+    protected string $secret;
 
     /**
      * The array of keys.
-     *
-     * @var array
      */
-    protected $keys;
+    protected array $keys;
 
     /**
      * The used algorithm.
-     *
-     * @var string
      */
-    protected $algo;
+    protected string $algo;
 
     /**
      * Constructor.

--- a/src/Token.php
+++ b/src/Token.php
@@ -15,10 +15,7 @@ use PHPOpenSourceSaver\JWTAuth\Validators\TokenValidator;
 
 class Token
 {
-    /**
-     * @var string
-     */
-    private $value;
+    private string $value;
 
     /**
      * Create a new JSON Web Token.

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -12,6 +12,7 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
+use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
@@ -28,11 +29,11 @@ use PHPOpenSourceSaver\JWTAuth\Validators\Validator;
 
 class BlacklistTest extends AbstractTestCase
 {
-    protected \Mockery\LegacyMockInterface $storage;
+    protected LegacyMockInterface $storage;
 
-    protected \PHPOpenSourceSaver\JWTAuth\Blacklist $blacklist;
+    protected Blacklist $blacklist;
 
-    protected \Mockery\LegacyMockInterface $validator;
+    protected LegacyMockInterface $validator;
 
     public function setUp(): void
     {

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -28,20 +28,11 @@ use PHPOpenSourceSaver\JWTAuth\Validators\Validator;
 
 class BlacklistTest extends AbstractTestCase
 {
-    /**
-     * @var Storage|MockInterface
-     */
-    protected $storage;
+    protected \Mockery\LegacyMockInterface $storage;
 
-    /**
-     * @var Blacklist
-     */
-    protected $blacklist;
+    protected \PHPOpenSourceSaver\JWTAuth\Blacklist $blacklist;
 
-    /**
-     * @var MockInterface|Validator
-     */
-    protected $validator;
+    protected \Mockery\LegacyMockInterface $validator;
 
     public function setUp(): void
     {

--- a/tests/Claims/ClaimTest.php
+++ b/tests/Claims/ClaimTest.php
@@ -18,10 +18,7 @@ use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class ClaimTest extends AbstractTestCase
 {
-    /**
-     * @var Expiration
-     */
-    protected $claim;
+    protected \PHPOpenSourceSaver\JWTAuth\Claims\Expiration $claim;
 
     public function setUp(): void
     {

--- a/tests/Claims/ClaimTest.php
+++ b/tests/Claims/ClaimTest.php
@@ -18,8 +18,11 @@ use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class ClaimTest extends AbstractTestCase
 {
-    protected \PHPOpenSourceSaver\JWTAuth\Claims\Expiration $claim;
+    protected Expiration $claim;
 
+    /**
+     * @throws InvalidClaimException
+     */
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -17,6 +17,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Mockery;
+use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
@@ -25,16 +26,20 @@ use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
 use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
 use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
 use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
 use PHPOpenSourceSaver\JWTAuth\Payload;
 use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class DatetimeClaimTest extends AbstractTestCase
 {
-    protected \Mockery\LegacyMockInterface $validator;
+    protected LegacyMockInterface $validator;
 
     protected array $claimsTimestamp;
 
+    /**
+     * @throws InvalidClaimException
+     */
     public function setUp(): void
     {
         parent::setUp();
@@ -52,7 +57,9 @@ class DatetimeClaimTest extends AbstractTestCase
         ];
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_handle_carbon_claims()
     {
         $testCarbon = Carbon::createFromTimestampUTC($this->testNowTimestamp);
@@ -124,7 +131,9 @@ class DatetimeClaimTest extends AbstractTestCase
         $this->assertEquals($payloadTimestamp, $payloadDatetime);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_handle_datetinterval_claims()
     {
         $testDateInterval = new DateInterval('PT1H');

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -31,15 +31,9 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class DatetimeClaimTest extends AbstractTestCase
 {
-    /**
-     * @var MockInterface|PayloadValidator
-     */
-    protected $validator;
+    protected \Mockery\LegacyMockInterface $validator;
 
-    /**
-     * @var array
-     */
-    protected $claimsTimestamp;
+    protected array $claimsTimestamp;
 
     public function setUp(): void
     {

--- a/tests/Claims/FactoryTest.php
+++ b/tests/Claims/FactoryTest.php
@@ -25,7 +25,7 @@ use PHPOpenSourceSaver\JWTAuth\Test\Fixtures\Foo;
 
 class FactoryTest extends AbstractTestCase
 {
-    protected \PHPOpenSourceSaver\JWTAuth\Claims\Factory $factory;
+    protected Factory $factory;
 
     public function setUp(): void
     {

--- a/tests/Claims/FactoryTest.php
+++ b/tests/Claims/FactoryTest.php
@@ -25,10 +25,7 @@ use PHPOpenSourceSaver\JWTAuth\Test\Fixtures\Foo;
 
 class FactoryTest extends AbstractTestCase
 {
-    /**
-     * @var Factory
-     */
-    protected $factory;
+    protected \PHPOpenSourceSaver\JWTAuth\Claims\Factory $factory;
 
     public function setUp(): void
     {

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -28,20 +28,11 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class FactoryTest extends AbstractTestCase
 {
-    /**
-     * @var MockInterface|ClaimFactory
-     */
-    protected $claimFactory;
+    protected \Mockery\LegacyMockInterface $claimFactory;
 
-    /**
-     * @var MockInterface|PayloadValidator
-     */
-    protected $validator;
+    protected \Mockery\LegacyMockInterface $validator;
 
-    /**
-     * @var Factory
-     */
-    protected $factory;
+    protected \PHPOpenSourceSaver\JWTAuth\Factory $factory;
 
     public function setUp(): void
     {

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -12,6 +12,7 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
+use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Custom;
@@ -22,17 +23,18 @@ use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
 use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
 use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
 use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
 use PHPOpenSourceSaver\JWTAuth\Factory;
 use PHPOpenSourceSaver\JWTAuth\Payload;
 use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class FactoryTest extends AbstractTestCase
 {
-    protected \Mockery\LegacyMockInterface $claimFactory;
+    protected LegacyMockInterface $claimFactory;
 
-    protected \Mockery\LegacyMockInterface $validator;
+    protected LegacyMockInterface $validator;
 
-    protected \PHPOpenSourceSaver\JWTAuth\Factory $factory;
+    protected Factory $factory;
 
     public function setUp(): void
     {
@@ -84,7 +86,9 @@ class FactoryTest extends AbstractTestCase
         $this->assertInstanceOf(Payload::class, $payload);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_return_a_payload_when_chaining_claim_methods()
     {
         $this->claimFactory->shouldReceive('get')->twice()->with('sub', 1)->andReturn(new Subject(1));
@@ -113,7 +117,9 @@ class FactoryTest extends AbstractTestCase
         $this->assertInstanceOf(Payload::class, $payload);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_return_a_payload_when_passing_miltidimensional_array_as_custom_claim_to_make_method()
     {
         // these are added from default claims
@@ -145,7 +151,9 @@ class FactoryTest extends AbstractTestCase
         $this->assertInstanceOf(Payload::class, $payload);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_exclude_the_exp_claim_when_setting_ttl_to_null()
     {
         // these are added from default claims
@@ -210,7 +218,9 @@ class FactoryTest extends AbstractTestCase
         $this->assertSame($this->factory->getDefaultClaims(), ['sub', 'iat']);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_get_payload_with_a_predefined_collection_of_claims()
     {
         $claims = [

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -343,9 +343,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_return_the_token_from_route()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(function () {
-            return $this->getRouteMock('foobar');
-        });
+        $request->setRouteResolver(fn() => $this->getRouteMock('foobar'));
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -372,9 +370,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_return_the_token_from_route_with_a_custom_param()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(function () {
-            return $this->getRouteMock('foobar', 'custom_route_param');
-        });
+        $request->setRouteResolver(fn() => $this->getRouteMock('foobar', 'custom_route_param'));
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -412,9 +408,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_ignore_lumen_request_arrays()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(function () {
-            return [false, ['uses' => 'someController'], ['token' => 'foobar']];
-        });
+        $request->setRouteResolver(fn() => [false, ['uses' => 'someController'], ['token' => 'foobar']]);
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -432,9 +426,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_accept_lumen_request_arrays_with_special_class()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(function () {
-            return [false, ['uses' => 'someController'], ['token' => 'foo.bar.baz']];
-        });
+        $request->setRouteResolver(fn() => [false, ['uses' => 'someController'], ['token' => 'foo.bar.baz']]);
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -452,9 +444,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_return_null_if_no_token_in_request()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(function () {
-            return $this->getRouteMock();
-        });
+        $request->setRouteResolver(fn() => $this->getRouteMock());
 
         $parser = new Parser($request);
         $parser->setChain([

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -343,7 +343,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_return_the_token_from_route()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(fn() => $this->getRouteMock('foobar'));
+        $request->setRouteResolver(fn () => $this->getRouteMock('foobar'));
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -370,7 +370,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_return_the_token_from_route_with_a_custom_param()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(fn() => $this->getRouteMock('foobar', 'custom_route_param'));
+        $request->setRouteResolver(fn () => $this->getRouteMock('foobar', 'custom_route_param'));
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -408,7 +408,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_ignore_lumen_request_arrays()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(fn() => [false, ['uses' => 'someController'], ['token' => 'foobar']]);
+        $request->setRouteResolver(fn () => [false, ['uses' => 'someController'], ['token' => 'foobar']]);
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -426,7 +426,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_accept_lumen_request_arrays_with_special_class()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(fn() => [false, ['uses' => 'someController'], ['token' => 'foo.bar.baz']]);
+        $request->setRouteResolver(fn () => [false, ['uses' => 'someController'], ['token' => 'foo.bar.baz']]);
 
         $parser = new Parser($request);
         $parser->setChain([
@@ -444,7 +444,7 @@ class ParserTest extends AbstractTestCase
     public function it_should_return_null_if_no_token_in_request()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
-        $request->setRouteResolver(fn() => $this->getRouteMock());
+        $request->setRouteResolver(fn () => $this->getRouteMock());
 
         $parser = new Parser($request);
         $parser->setChain([

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -28,25 +28,13 @@ use stdClass;
 
 class JWTAuthTest extends AbstractTestCase
 {
-    /**
-     * @var MockInterface|Manager
-     */
-    protected $manager;
+    protected \Mockery\LegacyMockInterface $manager;
 
-    /**
-     * @var MockInterface|Auth
-     */
-    protected $auth;
+    protected \Mockery\LegacyMockInterface $auth;
 
-    /**
-     * @var MockInterface|Parser
-     */
-    protected $parser;
+    protected \Mockery\LegacyMockInterface $parser;
 
-    /**
-     * @var JWTAuth
-     */
-    protected $jwtAuth;
+    protected \PHPOpenSourceSaver\JWTAuth\JWTAuth $jwtAuth;
 
     public function setUp(): void
     {

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -13,6 +13,7 @@ namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Illuminate\Http\Request;
 use Mockery;
+use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
@@ -28,13 +29,13 @@ use stdClass;
 
 class JWTAuthTest extends AbstractTestCase
 {
-    protected \Mockery\LegacyMockInterface $manager;
+    protected LegacyMockInterface $manager;
 
-    protected \Mockery\LegacyMockInterface $auth;
+    protected LegacyMockInterface $auth;
 
-    protected \Mockery\LegacyMockInterface $parser;
+    protected LegacyMockInterface $parser;
 
-    protected \PHPOpenSourceSaver\JWTAuth\JWTAuth $jwtAuth;
+    protected JWTAuth $jwtAuth;
 
     public function setUp(): void
     {

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -33,25 +33,13 @@ use PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub;
 
 class JWTGuardTest extends AbstractTestCase
 {
-    /**
-     * @var JWT|MockInterface
-     */
-    protected $jwt;
+    protected \Mockery\LegacyMockInterface $jwt;
 
-    /**
-     * @var UserProvider|MockInterface
-     */
-    protected $provider;
+    protected \Mockery\LegacyMockInterface $provider;
 
-    /**
-     * @var JWTGuard|MockInterface
-     */
-    protected $guard;
+    protected \PHPOpenSourceSaver\JWTAuth\JWTGuard $guard;
 
-    /**
-     * @var \lluminate\Contracts\Events\Dispatcher|\Mockery\MockInterface
-     */
-    protected $eventDispatcher;
+    protected \Mockery\LegacyMockInterface $eventDispatcher;
 
     public function setUp(): void
     {
@@ -546,9 +534,7 @@ class JWTGuardTest extends AbstractTestCase
     /** @test */
     public function it_should_be_macroable()
     {
-        $this->guard->macro('foo', function () {
-            return 'bar';
-        });
+        $this->guard->macro('foo', fn() => 'bar');
 
         $this->assertEquals('bar', $this->guard->foo());
     }

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -22,6 +22,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
 use Mockery;
+use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException;
@@ -33,13 +34,13 @@ use PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub;
 
 class JWTGuardTest extends AbstractTestCase
 {
-    protected \Mockery\LegacyMockInterface $jwt;
+    protected LegacyMockInterface $jwt;
 
-    protected \Mockery\LegacyMockInterface $provider;
+    protected LegacyMockInterface $provider;
 
-    protected \PHPOpenSourceSaver\JWTAuth\JWTGuard $guard;
+    protected JWTGuard $guard;
 
-    protected \Mockery\LegacyMockInterface $eventDispatcher;
+    protected LegacyMockInterface $eventDispatcher;
 
     public function setUp(): void
     {

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -12,6 +12,7 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
+use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
@@ -22,6 +23,7 @@ use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
 use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
 use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException;
 use PHPOpenSourceSaver\JWTAuth\Factory;
@@ -32,15 +34,15 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class ManagerTest extends AbstractTestCase
 {
-    protected \Mockery\LegacyMockInterface $jwt;
+    protected LegacyMockInterface $jwt;
 
-    protected \Mockery\LegacyMockInterface $blacklist;
+    protected LegacyMockInterface $blacklist;
 
-    protected \Mockery\LegacyMockInterface $factory;
+    protected LegacyMockInterface $factory;
 
-    protected \PHPOpenSourceSaver\JWTAuth\Manager $manager;
+    protected Manager $manager;
 
-    protected \Mockery\LegacyMockInterface $validator;
+    protected LegacyMockInterface $validator;
 
     public function setUp(): void
     {
@@ -53,7 +55,9 @@ class ManagerTest extends AbstractTestCase
         $this->validator = Mockery::mock(PayloadValidator::class);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_encode_a_payload()
     {
         $claims = [
@@ -77,7 +81,9 @@ class ManagerTest extends AbstractTestCase
         $this->assertEquals($token, 'foo.bar.baz');
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException|TokenBlacklistedException
+     */
     public function it_should_decode_a_token()
     {
         $claims = [
@@ -109,7 +115,9 @@ class ManagerTest extends AbstractTestCase
         $this->assertSame($payload->count(), 6);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_throw_exception_when_token_is_blacklisted()
     {
         $this->expectException(TokenBlacklistedException::class);
@@ -140,7 +148,9 @@ class ManagerTest extends AbstractTestCase
         $this->manager->decode($token);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_refresh_a_token()
     {
         $claims = [
@@ -174,7 +184,9 @@ class ManagerTest extends AbstractTestCase
         $this->assertEquals('baz.bar.foo', $token);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_invalidate_a_token()
     {
         $claims = [
@@ -204,7 +216,9 @@ class ManagerTest extends AbstractTestCase
         $this->manager->invalidate($token);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_force_invalidate_a_token_forever()
     {
         $claims = [

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -32,30 +32,15 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class ManagerTest extends AbstractTestCase
 {
-    /**
-     * @var MockInterface|JWT
-     */
-    protected $jwt;
+    protected \Mockery\LegacyMockInterface $jwt;
 
-    /**
-     * @var MockInterface|Blacklist
-     */
-    protected $blacklist;
+    protected \Mockery\LegacyMockInterface $blacklist;
 
-    /**
-     * @var MockInterface|Factory
-     */
-    protected $factory;
+    protected \Mockery\LegacyMockInterface $factory;
 
-    /**
-     * @var Manager
-     */
-    protected $manager;
+    protected \PHPOpenSourceSaver\JWTAuth\Manager $manager;
 
-    /**
-     * @var MockInterface
-     */
-    protected $validator;
+    protected \Mockery\LegacyMockInterface $validator;
 
     public function setUp(): void
     {

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -29,10 +29,7 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class PayloadTest extends AbstractTestCase
 {
-    /**
-     * @var MockInterface|PayloadValidator
-     */
-    protected $validator;
+    protected ?\Mockery\LegacyMockInterface $validator = null;
 
     /**
      * @var Payload
@@ -114,9 +111,7 @@ class PayloadTest extends AbstractTestCase
         $this->assertSame($this->payload->get('sub'), 1);
 
         $this->assertSame(
-            $this->payload->get(function () {
-                return 'jti';
-            }),
+            $this->payload->get(fn() => 'jti'),
             'foo'
         );
     }

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -13,7 +13,7 @@ namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use BadMethodCallException;
 use Mockery;
-use Mockery\MockInterface;
+use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Audience;
 use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
@@ -23,13 +23,14 @@ use PHPOpenSourceSaver\JWTAuth\Claims\Issuer;
 use PHPOpenSourceSaver\JWTAuth\Claims\JwtId;
 use PHPOpenSourceSaver\JWTAuth\Claims\NotBefore;
 use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\PayloadException;
 use PHPOpenSourceSaver\JWTAuth\Payload;
 use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class PayloadTest extends AbstractTestCase
 {
-    protected ?\Mockery\LegacyMockInterface $validator = null;
+    protected ?LegacyMockInterface $validator = null;
 
     /**
      * @var Payload
@@ -47,6 +48,7 @@ class PayloadTest extends AbstractTestCase
      * @param array $extraClaims
      *
      * @return Payload
+     * @throws InvalidClaimException
      */
     private function getTestPayload(array $extraClaims = [])
     {
@@ -111,7 +113,7 @@ class PayloadTest extends AbstractTestCase
         $this->assertSame($this->payload->get('sub'), 1);
 
         $this->assertSame(
-            $this->payload->get(fn() => 'jti'),
+            $this->payload->get(fn () => 'jti'),
             'foo'
         );
     }

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -26,7 +26,7 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class PayloadValidatorTest extends AbstractTestCase
 {
-    protected \PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator $validator;
+    protected PayloadValidator $validator;
 
     public function setUp(): void
     {
@@ -35,7 +35,9 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator = new PayloadValidator();
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_return_true_when_providing_a_valid_payload()
     {
         $claims = [
@@ -52,7 +54,9 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->assertTrue($this->validator->isValid($collection));
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_throw_an_exception_when_providing_an_expired_payload()
     {
         $this->expectException(TokenExpiredException::class);
@@ -72,7 +76,9 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator->check($collection);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_throw_an_exception_when_providing_an_invalid_nbf_claim()
     {
         $this->expectException(TokenInvalidException::class);
@@ -112,7 +118,9 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator->check($collection);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_throw_an_exception_when_providing_an_invalid_payload()
     {
         $this->expectException(TokenInvalidException::class);
@@ -148,7 +156,9 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator->check($collection);
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_set_the_required_claims()
     {
         $claims = [
@@ -161,7 +171,9 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->assertTrue($this->validator->setRequiredClaims(['iss', 'sub'])->isValid($collection));
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_check_the_token_in_the_refresh_context()
     {
         $claims = [
@@ -180,7 +192,9 @@ class PayloadValidatorTest extends AbstractTestCase
         );
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_return_true_if_the_refresh_ttl_is_null()
     {
         $claims = [
@@ -199,7 +213,9 @@ class PayloadValidatorTest extends AbstractTestCase
         );
     }
 
-    /** @test */
+    /** @test
+     * @throws InvalidClaimException
+     */
     public function it_should_throw_an_exception_if_the_token_cannot_be_refreshed()
     {
         $this->expectException(TokenExpiredException::class);

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -26,10 +26,7 @@ use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
 class PayloadValidatorTest extends AbstractTestCase
 {
-    /**
-     * @var PayloadValidator
-     */
-    protected $validator;
+    protected \PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator $validator;
 
     public function setUp(): void
     {

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -35,7 +35,8 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator = new PayloadValidator();
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_return_true_when_providing_a_valid_payload()
@@ -54,7 +55,8 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->assertTrue($this->validator->isValid($collection));
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_throw_an_exception_when_providing_an_expired_payload()
@@ -76,7 +78,8 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator->check($collection);
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_throw_an_exception_when_providing_an_invalid_nbf_claim()
@@ -118,7 +121,8 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator->check($collection);
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_throw_an_exception_when_providing_an_invalid_payload()
@@ -156,7 +160,8 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->validator->check($collection);
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_set_the_required_claims()
@@ -171,7 +176,8 @@ class PayloadValidatorTest extends AbstractTestCase
         $this->assertTrue($this->validator->setRequiredClaims(['iss', 'sub'])->isValid($collection));
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_check_the_token_in_the_refresh_context()
@@ -192,7 +198,8 @@ class PayloadValidatorTest extends AbstractTestCase
         );
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_return_true_if_the_refresh_ttl_is_null()
@@ -213,7 +220,8 @@ class PayloadValidatorTest extends AbstractTestCase
         );
     }
 
-    /** @test
+    /**
+     * @test
      * @throws InvalidClaimException
      */
     public function it_should_throw_an_exception_if_the_token_cannot_be_refreshed()


### PR DESCRIPTION
As I stated in [#40](https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/40#issuecomment-973275527), right now it is impossible to use this packages with PHP version lower than 7.4, even it is stated 7.2 in `composer.json`. 

Trying to install packageon 7.2 results into error:
<details>
<summary>Error</summary>

```
/var/www/html # php -v
PHP 7.2.34 (cli) (built: Dec 17 2020 10:26:11) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies

/var/www/html # composer require php-open-source-saver/jwt-auth
Using version ^1.2 for php-open-source-saver/jwt-auth
./composer.json has been updated
Running composer update php-open-source-saver/jwt-auth
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - lcobucci/jwt[4.0.0, ..., 4.1.5] require php ^7.4 || ^8.0 -> your php version (7.2.34) does not satisfy that requirement.
    - php-open-source-saver/jwt-auth 1.2.0 requires lcobucci/jwt ^4.0 -> satisfiable by lcobucci/jwt[4.0.0, ..., 4.1.5].
    - Root composer.json requires php-open-source-saver/jwt-auth ^1.2 -> satisfiable by php-open-source-saver/jwt-auth[1.2.0].


Installation failed, reverting ./composer.json to its original content.
```
</details>

So I've updated minimal PHP version to 7.4 and processed all files with Rector to latest 7.4 language features