### PR TITLE
php-cs-fixer: switch to `@Symfony` rule set

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 return (new Config())
     ->setFinder($finder)
     ->setRules([
-                   '@PSR12' => true,
+                   '@Symfony' => true,
                    'header_comment' => [
                        'comment_type' => 'comment',
                        'header' => <<<HEREDOC

--- a/config/config.php
+++ b/config/config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | JWT Authentication Secret
@@ -36,7 +35,6 @@ return [
     */
 
     'keys' => [
-
         /*
         |--------------------------------------------------------------------------
         | Public Key
@@ -73,7 +71,6 @@ return [
         */
 
         'passphrase' => env('JWT_PASSPHRASE'),
-
     ],
 
     /*
@@ -267,7 +264,6 @@ return [
     */
 
     'providers' => [
-
         /*
         |--------------------------------------------------------------------------
         | JWT Provider
@@ -301,5 +297,4 @@ return [
 
         'storage' => PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate::class,
     ],
-
 ];

--- a/rector.php
+++ b/rector.php
@@ -11,8 +11,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/tests'
+        __DIR__.'/src',
+        __DIR__.'/tests',
     ]);
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
 

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -48,8 +48,6 @@ class Blacklist
     /**
      * Constructor.
      *
-     * @param Storage $storage
-     *
      * @return void
      */
     public function __construct(Storage $storage)
@@ -59,8 +57,6 @@ class Blacklist
 
     /**
      * Add the token (jti claim) to the blacklist.
-     *
-     * @param Payload $payload
      *
      * @return bool
      */
@@ -89,8 +85,6 @@ class Blacklist
     /**
      * Get the number of minutes until the token expiry.
      *
-     * @param Payload $payload
-     *
      * @return int
      */
     protected function getMinutesUntilExpired(Payload $payload)
@@ -107,8 +101,6 @@ class Blacklist
     /**
      * Add the token (jti claim) to the blacklist indefinitely.
      *
-     * @param Payload $payload
-     *
      * @return bool
      */
     public function addForever(Payload $payload)
@@ -121,8 +113,6 @@ class Blacklist
     /**
      * Determine whether the token has been blacklisted.
      *
-     * @param Payload $payload
-     *
      * @return bool
      */
     public function has(Payload $payload)
@@ -130,7 +120,7 @@ class Blacklist
         $val = $this->storage->get($this->getKey($payload));
 
         // exit early if the token was blacklisted forever,
-        if ($val === 'forever') {
+        if ('forever' === $val) {
             return true;
         }
 
@@ -140,8 +130,6 @@ class Blacklist
 
     /**
      * Remove the token (jti claim) from the blacklist.
-     *
-     * @param Payload $payload
      *
      * @return bool
      */
@@ -182,7 +170,7 @@ class Blacklist
      */
     public function setGracePeriod($gracePeriod)
     {
-        $this->gracePeriod = (int)$gracePeriod;
+        $this->gracePeriod = (int) $gracePeriod;
 
         return $this;
     }
@@ -199,8 +187,6 @@ class Blacklist
 
     /**
      * Get the unique key held within the blacklist.
-     *
-     * @param Payload $payload
      *
      * @return mixed
      */
@@ -232,7 +218,7 @@ class Blacklist
      */
     public function setRefreshTTL($ttl)
     {
-        $this->refreshTTL = (int)$ttl;
+        $this->refreshTTL = (int) $ttl;
 
         return $this;
     }

--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -38,6 +38,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      * @param mixed $value
      *
      * @return void
+     *
      * @throws InvalidClaimException
      */
     public function __construct($value)
@@ -48,7 +49,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Set the claim value, and call a validate method.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @throws InvalidClaimException
      *
@@ -74,7 +75,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Set the claim name.
      *
-     * @param  string  $name
+     * @param string $name
      *
      * @return $this
      */
@@ -98,7 +99,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Validate the claim in a standalone Claim context.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @return bool
      */
@@ -120,7 +121,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Validate the Claim within a refresh context.
      *
-     * @param  int  $refreshTTL
+     * @param int $refreshTTL
      *
      * @return bool
      */
@@ -132,8 +133,8 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Checks if the value matches the claim.
      *
-     * @param  mixed  $value
-     * @param  bool  $strict
+     * @param mixed $value
+     * @param bool  $strict
      *
      * @return bool
      */
@@ -165,7 +166,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Get the claim as JSON.
      *
-     * @param  int  $options
+     * @param int $options
      *
      * @return string
      */

--- a/src/Claims/Collection.php
+++ b/src/Claims/Collection.php
@@ -20,7 +20,7 @@ class Collection extends IlluminateCollection
     /**
      * Create a new collection.
      *
-     * @param  mixed  $items
+     * @param mixed $items
      *
      * @return void
      */
@@ -33,8 +33,7 @@ class Collection extends IlluminateCollection
      * Get a Claim instance by it's unique name.
      *
      * @param string $name
-     * @param callable|null $callback
-     * @param mixed $default
+     * @param mixed  $default
      *
      * @return Claim
      */
@@ -48,7 +47,7 @@ class Collection extends IlluminateCollection
     /**
      * Validate each claim under a given context.
      *
-     * @param  string  $context
+     * @param string $context
      *
      * @return $this
      */
@@ -70,7 +69,7 @@ class Collection extends IlluminateCollection
     /**
      * Determine if the Collection contains all of the given keys.
      *
-     * @param  mixed  $claims
+     * @param mixed $claims
      *
      * @return bool
      */
@@ -102,7 +101,7 @@ class Collection extends IlluminateCollection
     /**
      * Ensure that the given claims array is keyed by the claim name.
      *
-     * @param  mixed  $items
+     * @param mixed $items
      *
      * @return array
      */
@@ -110,7 +109,7 @@ class Collection extends IlluminateCollection
     {
         $claims = [];
         foreach ($items as $key => $value) {
-            if (! is_string($key) && $value instanceof Claim) {
+            if (!is_string($key) && $value instanceof Claim) {
                 $key = $value->getName();
             }
 

--- a/src/Claims/Custom.php
+++ b/src/Claims/Custom.php
@@ -18,9 +18,10 @@ class Custom extends Claim
 {
     /**
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return void
+     *
      * @throws InvalidClaimException
      */
     public function __construct($name, $value)

--- a/src/Claims/DatetimeTrait.php
+++ b/src/Claims/DatetimeTrait.php
@@ -29,7 +29,7 @@ trait DatetimeTrait
     /**
      * Set the claim value, and call a validate method.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @throws InvalidClaimException
      *
@@ -53,7 +53,7 @@ trait DatetimeTrait
      */
     public function validateCreate($value)
     {
-        if (! is_numeric($value)) {
+        if (!is_numeric($value)) {
             throw new InvalidClaimException($this);
         }
 
@@ -63,7 +63,7 @@ trait DatetimeTrait
     /**
      * Determine whether the value is in the future.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @return bool
      */
@@ -75,7 +75,7 @@ trait DatetimeTrait
     /**
      * Determine whether the value is in the past.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @return bool
      */
@@ -87,7 +87,7 @@ trait DatetimeTrait
     /**
      * Set the leeway in seconds.
      *
-     * @param  int  $leeway
+     * @param int $leeway
      *
      * @return $this
      */

--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -58,8 +58,6 @@ class Factory
     /**
      * Constructor.
      *
-     * @param Request $request
-     *
      * @return void
      */
     public function __construct(Request $request)
@@ -71,9 +69,10 @@ class Factory
      * Get the instance of the claim when passing the name and value.
      *
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return Claim
+     *
      * @throws InvalidClaimException
      */
     public function get($name, $value)
@@ -92,7 +91,7 @@ class Factory
     /**
      * Check whether the claim exists.
      *
-     * @param  string  $name
+     * @param string $name
      *
      * @return bool
      */
@@ -107,6 +106,7 @@ class Factory
      * @param string $name
      *
      * @return Claim
+     *
      * @throws InvalidClaimException
      */
     public function make($name)
@@ -167,8 +167,8 @@ class Factory
     /**
      * Add a new claim mapping.
      *
-     * @param  string  $name
-     * @param  string  $classPath
+     * @param string $name
+     * @param string $classPath
      *
      * @return $this
      */
@@ -182,8 +182,6 @@ class Factory
     /**
      * Set the request instance.
      *
-     * @param Request $request
-     *
      * @return $this
      */
     public function setRequest(Request $request)
@@ -196,7 +194,7 @@ class Factory
     /**
      * Set the token ttl (in minutes).
      *
-     * @param  int  $ttl
+     * @param int $ttl
      *
      * @return $this
      */
@@ -220,7 +218,7 @@ class Factory
     /**
      * Set the leeway in seconds.
      *
-     * @param  int  $leeway
+     * @param int $leeway
      *
      * @return $this
      */

--- a/src/Claims/NotBefore.php
+++ b/src/Claims/NotBefore.php
@@ -25,6 +25,7 @@ class NotBefore extends Claim
 
     /**
      * {@inheritdoc}
+     *
      * @throws TokenInvalidException
      */
     public function validatePayload()

--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -49,11 +49,11 @@ class JWTGenerateSecretCommand extends Command
             return;
         }
 
-        if (file_exists($path = $this->envPath()) === false) {
+        if (false === file_exists($path = $this->envPath())) {
             return $this->displayKey($key);
         }
 
-        if (Str::contains(file_get_contents($path), 'JWT_SECRET') === false) {
+        if (false === Str::contains(file_get_contents($path), 'JWT_SECRET')) {
             // create new entry
             file_put_contents($path, PHP_EOL."JWT_SECRET=$key".PHP_EOL, FILE_APPEND);
         } else {
@@ -63,7 +63,7 @@ class JWTGenerateSecretCommand extends Command
                 return;
             }
 
-            if ($this->isConfirmed() === false) {
+            if (false === $this->isConfirmed()) {
                 $this->comment('Phew... No changes were made to your secret key.');
 
                 return;
@@ -83,7 +83,7 @@ class JWTGenerateSecretCommand extends Command
     /**
      * Display the key.
      *
-     * @param  string  $key
+     * @param string $key
      *
      * @return void
      */

--- a/src/Contracts/Claim.php
+++ b/src/Contracts/Claim.php
@@ -19,7 +19,7 @@ interface Claim
     /**
      * Set the claim value, and call a validate method.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @throws InvalidClaimException
      *
@@ -37,7 +37,7 @@ interface Claim
     /**
      * Set the claim name.
      *
-     * @param  string  $name
+     * @param string $name
      *
      * @return $this
      */
@@ -53,7 +53,7 @@ interface Claim
     /**
      * Validate the Claim value.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @return bool
      */

--- a/src/Contracts/Http/Parser.php
+++ b/src/Contracts/Http/Parser.php
@@ -19,9 +19,7 @@ interface Parser
     /**
      * Parse the request.
      *
-     * @param Request $request
-     *
-     * @return null|string
+     * @return string|null
      */
     public function parse(Request $request);
 }

--- a/src/Contracts/Providers/Auth.php
+++ b/src/Contracts/Providers/Auth.php
@@ -17,8 +17,6 @@ interface Auth
     /**
      * Check a user's credentials.
      *
-     * @param  array  $credentials
-     *
      * @return mixed
      */
     public function byCredentials(array $credentials);
@@ -26,7 +24,7 @@ interface Auth
     /**
      * Authenticate a user via the id.
      *
-     * @param  mixed  $id
+     * @param mixed $id
      *
      * @return mixed
      */

--- a/src/Contracts/Providers/JWT.php
+++ b/src/Contracts/Providers/JWT.php
@@ -15,14 +15,12 @@ namespace PHPOpenSourceSaver\JWTAuth\Contracts\Providers;
 interface JWT
 {
     /**
-     * @param  array  $payload
-     *
      * @return string
      */
     public function encode(array $payload);
 
     /**
-     * @param  string  $token
+     * @param string $token
      *
      * @return array
      */

--- a/src/Contracts/Providers/Storage.php
+++ b/src/Contracts/Providers/Storage.php
@@ -15,31 +15,31 @@ namespace PHPOpenSourceSaver\JWTAuth\Contracts\Providers;
 interface Storage
 {
     /**
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  int  $minutes
+     * @param string $key
+     * @param mixed  $value
+     * @param int    $minutes
      *
      * @return void
      */
     public function add($key, $value, $minutes);
 
     /**
-     * @param  string  $key
-     * @param  mixed  $value
+     * @param string $key
+     * @param mixed  $value
      *
      * @return void
      */
     public function forever($key, $value);
 
     /**
-     * @param  string  $key
+     * @param string $key
      *
      * @return mixed
      */
     public function get($key);
 
     /**
-     * @param  string  $key
+     * @param string $key
      *
      * @return bool
      */

--- a/src/Contracts/Validator.php
+++ b/src/Contracts/Validator.php
@@ -17,7 +17,7 @@ interface Validator
     /**
      * Perform some checks on the value.
      *
-     * @param  mixed  $value
+     * @param mixed $value
      *
      * @return void
      */
@@ -26,7 +26,7 @@ interface Validator
     /**
      * Helper function to return a boolean.
      *
-     * @param  array  $value
+     * @param array $value
      *
      * @return bool
      */

--- a/src/Exceptions/InvalidClaimException.php
+++ b/src/Exceptions/InvalidClaimException.php
@@ -20,9 +20,7 @@ class InvalidClaimException extends JWTException
     /**
      * Constructor.
      *
-     * @param Claim $claim
-     * @param  int  $code
-     * @param Exception|null  $previous
+     * @param int $code
      *
      * @return void
      */

--- a/src/Exceptions/PayloadException.php
+++ b/src/Exceptions/PayloadException.php
@@ -14,5 +14,4 @@ namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class PayloadException extends JWTException
 {
-    //
 }

--- a/src/Exceptions/TokenBlacklistedException.php
+++ b/src/Exceptions/TokenBlacklistedException.php
@@ -14,5 +14,4 @@ namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class TokenBlacklistedException extends TokenInvalidException
 {
-    //
 }

--- a/src/Exceptions/TokenExpiredException.php
+++ b/src/Exceptions/TokenExpiredException.php
@@ -14,5 +14,4 @@ namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class TokenExpiredException extends JWTException
 {
-    //
 }

--- a/src/Exceptions/TokenInvalidException.php
+++ b/src/Exceptions/TokenInvalidException.php
@@ -14,5 +14,4 @@ namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class TokenInvalidException extends JWTException
 {
-    //
 }

--- a/src/Exceptions/UserNotDefinedException.php
+++ b/src/Exceptions/UserNotDefinedException.php
@@ -14,5 +14,4 @@ namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
 class UserNotDefinedException extends JWTException
 {
-    //
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -61,9 +61,6 @@ class Factory
     /**
      * Constructor.
      *
-     * @param ClaimFactory $claimFactory
-     * @param PayloadValidator $validator
-     *
      * @return void
      */
     public function __construct(ClaimFactory $claimFactory, PayloadValidator $validator)
@@ -104,8 +101,6 @@ class Factory
     /**
      * Add an array of claims to the Payload.
      *
-     * @param array $claims
-     *
      * @return $this
      */
     protected function addClaims(array $claims)
@@ -121,7 +116,7 @@ class Factory
      * Add a claim to the Payload.
      *
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return $this
      */
@@ -140,7 +135,7 @@ class Factory
     protected function buildClaims()
     {
         // remove the exp claim if it exists and the ttl is null
-        if ($this->claimFactory->getTTL() === null && $key = array_search('exp', $this->defaultClaims)) {
+        if (null === $this->claimFactory->getTTL() && $key = array_search('exp', $this->defaultClaims)) {
             unset($this->defaultClaims[$key]);
         }
 
@@ -178,8 +173,6 @@ class Factory
     /**
      * Get a Payload instance with a claims collection.
      *
-     * @param Collection $claims
-     *
      * @return Payload
      */
     public function withClaims(Collection $claims)
@@ -189,8 +182,6 @@ class Factory
 
     /**
      * Set the default claims to be added to the Payload.
-     *
-     * @param array $claims
      *
      * @return $this
      */
@@ -249,7 +240,7 @@ class Factory
      * Magically add a claim.
      *
      * @param string $method
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return $this
      */

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -23,11 +23,10 @@ class Authenticate extends BaseMiddleware
      * Handle an incoming request.
      *
      * @param Request $request
-     * @param Closure $next
      *
      * @return mixed
-     * @throws UnauthorizedHttpException
      *
+     * @throws UnauthorizedHttpException
      */
     public function handle($request, Closure $next)
     {

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -23,9 +23,9 @@ class AuthenticateAndRenew extends BaseMiddleware
      * Handle an incoming request.
      *
      * @param Request $request
-     * @param Closure $next
      *
      * @return mixed
+     *
      * @throws UnauthorizedHttpException
      */
     public function handle($request, Closure $next)

--- a/src/Http/Middleware/BaseMiddleware.php
+++ b/src/Http/Middleware/BaseMiddleware.php
@@ -31,8 +31,6 @@ abstract class BaseMiddleware
     /**
      * Create a new BaseMiddleware instance.
      *
-     * @param JWTAuth $auth
-     *
      * @return void
      */
     public function __construct(JWTAuth $auth)
@@ -43,11 +41,9 @@ abstract class BaseMiddleware
     /**
      * Check the request for the presence of a token.
      *
-     * @param Request $request
-     *
      * @return void
-     * @throws BadRequestHttpException
      *
+     * @throws BadRequestHttpException
      */
     public function checkForToken(Request $request)
     {
@@ -59,11 +55,9 @@ abstract class BaseMiddleware
     /**
      * Attempt to authenticate a user via the token in the request.
      *
-     * @param Request $request
-     *
      * @return void
-     * @throws UnauthorizedHttpException
      *
+     * @throws UnauthorizedHttpException
      */
     public function authenticate(Request $request)
     {
@@ -82,14 +76,14 @@ abstract class BaseMiddleware
      * Set the authentication header.
      *
      * @param Response|JsonResponse $response
-     * @param string|null $token
+     * @param string|null           $token
      *
      * @return Response|JsonResponse
      */
     protected function setAuthenticationHeader($response, $token = null)
     {
         $token = $token ?: $this->auth->refresh();
-        $response->headers->set('Authorization', 'Bearer ' . $token);
+        $response->headers->set('Authorization', 'Bearer '.$token);
 
         return $response;
     }

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -23,7 +23,6 @@ class Check extends BaseMiddleware
      * Handle an incoming request.
      *
      * @param Request $request
-     * @param Closure $next
      *
      * @return mixed
      */
@@ -33,7 +32,6 @@ class Check extends BaseMiddleware
             try {
                 $this->auth->parseToken()->authenticate();
             } catch (Exception $e) {
-                //
             }
         }
 

--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -24,9 +24,9 @@ class RefreshToken extends BaseMiddleware
      * Handle an incoming request.
      *
      * @param Request $request
-     * @param Closure $next
      *
      * @return mixed
+     *
      * @throws UnauthorizedHttpException
      */
     public function handle($request, Closure $next)

--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -34,9 +34,7 @@ class AuthHeaders implements ParserContract
     /**
      * Attempt to parse the token from some other possible headers.
      *
-     * @param Request $request
-     *
-     * @return null|string
+     * @return string|null
      */
     protected function fromAltHeaders(Request $request)
     {
@@ -46,9 +44,7 @@ class AuthHeaders implements ParserContract
     /**
      * Try to parse the token from the request header.
      *
-     * @param Request $request
-     *
-     * @return null|string
+     * @return string|null
      */
     public function parse(Request $request)
     {

--- a/src/Http/Parser/Cookies.php
+++ b/src/Http/Parser/Cookies.php
@@ -37,9 +37,8 @@ class Cookies implements ParserContract
     /**
      * Try to parse the token from the request cookies.
      *
-     * @param Request $request
+     * @return string|null
      *
-     * @return null|string
      * @throws TokenInvalidException
      */
     public function parse(Request $request)

--- a/src/Http/Parser/InputSource.php
+++ b/src/Http/Parser/InputSource.php
@@ -22,9 +22,7 @@ class InputSource implements ParserContract
     /**
      * Try to parse the token from the request input source.
      *
-     * @param Request $request
-     *
-     * @return null|string
+     * @return string|null
      */
     public function parse(Request $request)
     {

--- a/src/Http/Parser/LumenRouteParams.php
+++ b/src/Http/Parser/LumenRouteParams.php
@@ -20,15 +20,13 @@ class LumenRouteParams extends RouteParams
     /**
      * Try to get the token from the route parameters.
      *
-     * @param Request $request
-     *
-     * @return null|string
+     * @return string|null
      */
     public function parse(Request $request)
     {
         // WARNING: Only use this parser if you know what you're doing!
         // It will only work with poorly-specified aspects of certain Lumen releases.
         // Route is the expected kind of array, and has a parameter with the key we want.
-        return Arr::get($request->route(), '2.' . $this->key);
+        return Arr::get($request->route(), '2.'.$this->key);
     }
 }

--- a/src/Http/Parser/Parser.php
+++ b/src/Http/Parser/Parser.php
@@ -29,9 +29,6 @@ class Parser
     /**
      * Constructor.
      *
-     * @param Request $request
-     * @param array $chain
-     *
      * @return void
      */
     public function __construct(Request $request, array $chain = [])
@@ -67,8 +64,6 @@ class Parser
     /**
      * Set the order of the parser chain.
      *
-     * @param array $chain
-     *
      * @return $this
      */
     public function setChain(array $chain)
@@ -80,8 +75,6 @@ class Parser
 
     /**
      * Alias for setting the order of the chain.
-     *
-     * @param array $chain
      *
      * @return $this
      */
@@ -112,13 +105,11 @@ class Parser
      */
     public function hasToken()
     {
-        return $this->parseToken() !== null;
+        return null !== $this->parseToken();
     }
 
     /**
      * Set the request instance.
-     *
-     * @param Request $request
      *
      * @return $this
      */

--- a/src/Http/Parser/QueryString.php
+++ b/src/Http/Parser/QueryString.php
@@ -22,9 +22,7 @@ class QueryString implements ParserContract
     /**
      * Try to parse the token from the request query string.
      *
-     * @param Request $request
-     *
-     * @return null|string
+     * @return string|null
      */
     public function parse(Request $request)
     {

--- a/src/Http/Parser/RouteParams.php
+++ b/src/Http/Parser/RouteParams.php
@@ -22,9 +22,7 @@ class RouteParams implements ParserContract
     /**
      * Try to get the token from the route parameters.
      *
-     * @param Request $request
-     *
-     * @return null|string
+     * @return string|null
      */
     public function parse(Request $request)
     {

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -54,9 +54,6 @@ class JWT
     /**
      * JWT constructor.
      *
-     * @param Manager $manager
-     * @param Parser $parser
-     *
      * @return void
      */
     public function __construct(Manager $manager, Parser $parser)
@@ -67,8 +64,6 @@ class JWT
 
     /**
      * Generate a token for a given subject.
-     *
-     * @param JWTSubject $subject
      *
      * @return string
      */
@@ -81,8 +76,6 @@ class JWT
 
     /**
      * Alias to generate a token for a given user.
-     *
-     * @param JWTSubject $user
      *
      * @return string
      */
@@ -129,8 +122,8 @@ class JWT
      * the token is valid i.e. not expired or blacklisted.
      *
      * @return Payload
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     public function checkOrFail()
     {
@@ -162,7 +155,7 @@ class JWT
      */
     public function getToken()
     {
-        if ($this->token === null) {
+        if (null === $this->token) {
             try {
                 $this->parseToken();
             } catch (JWTException $e) {
@@ -177,8 +170,8 @@ class JWT
      * Parse the token from the request.
      *
      * @return $this
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     public function parseToken()
     {
@@ -226,8 +219,6 @@ class JWT
     /**
      * Create a Payload instance.
      *
-     * @param JWTSubject $subject
-     *
      * @return Payload
      */
     public function makePayload(JWTSubject $subject)
@@ -237,8 +228,6 @@ class JWT
 
     /**
      * Build the claims array and return it.
-     *
-     * @param JWTSubject $subject
      *
      * @return array
      */
@@ -253,8 +242,6 @@ class JWT
 
     /**
      * Get the claims associated with a given subject.
-     *
-     * @param JWTSubject $subject
      *
      * @return array
      */
@@ -323,8 +310,8 @@ class JWT
      * Ensure that a token is available.
      *
      * @return void
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     protected function requireToken()
     {
@@ -335,8 +322,6 @@ class JWT
 
     /**
      * Set the request instance.
-     *
-     * @param Request $request
      *
      * @return $this
      */
@@ -405,11 +390,11 @@ class JWT
      * Magically call the JWT Manager.
      *
      * @param string $method
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return mixed
-     * @throws BadMethodCallException
      *
+     * @throws BadMethodCallException
      */
     public function __call($method, $parameters)
     {

--- a/src/JWTAuth.php
+++ b/src/JWTAuth.php
@@ -28,10 +28,6 @@ class JWTAuth extends JWT
     /**
      * Constructor.
      *
-     * @param Manager $manager
-     * @param Auth $auth
-     * @param Parser $parser
-     *
      * @return void
      */
     public function __construct(Manager $manager, Auth $auth, Parser $parser)
@@ -42,8 +38,6 @@ class JWTAuth extends JWT
 
     /**
      * Attempt to authenticate the user and return the token.
-     *
-     * @param array $credentials
      *
      * @return false|string
      */

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -76,10 +76,6 @@ class JWTGuard implements Guard
     /**
      * Instantiate the class.
      *
-     * @param JWT $jwt
-     * @param UserProvider $provider
-     * @param Request $request
-     *
      * @return void
      */
     public function __construct(JWT $jwt, UserProvider $provider, Request $request, Dispatcher $eventDispatcher)
@@ -97,7 +93,7 @@ class JWTGuard implements Guard
      */
     public function user()
     {
-        if ($this->user !== null) {
+        if (null !== $this->user) {
             return $this->user;
         }
 
@@ -114,8 +110,8 @@ class JWTGuard implements Guard
      * Get the currently authenticated user or throws an exception.
      *
      * @return Authenticatable
-     * @throws UserNotDefinedException
      *
+     * @throws UserNotDefinedException
      */
     public function userOrFail()
     {
@@ -129,19 +125,16 @@ class JWTGuard implements Guard
     /**
      * Validate a user's credentials.
      *
-     * @param array $credentials
-     *
      * @return bool
      */
     public function validate(array $credentials = [])
     {
-        return (bool)$this->attempt($credentials, false);
+        return (bool) $this->attempt($credentials, false);
     }
 
     /**
      * Attempt to authenticate the user using the given credentials and return the token.
      *
-     * @param array $credentials
      * @param bool $login
      *
      * @return bool|string
@@ -163,8 +156,6 @@ class JWTGuard implements Guard
 
     /**
      * Create a token for a user.
-     *
-     * @param JWTSubject $user
      *
      * @return string
      */
@@ -237,8 +228,6 @@ class JWTGuard implements Guard
     /**
      * Log a user into the application using their credentials.
      *
-     * @param array $credentials
-     *
      * @return bool
      */
     public function once(array $credentials = [])
@@ -284,8 +273,6 @@ class JWTGuard implements Guard
 
     /**
      * Add any custom claims.
-     *
-     * @param array $claims
      *
      * @return $this
      */
@@ -357,8 +344,6 @@ class JWTGuard implements Guard
     /**
      * Set the user provider used by the guard.
      *
-     * @param UserProvider $provider
-     *
      * @return $this
      */
     public function setProvider(UserProvider $provider)
@@ -381,7 +366,6 @@ class JWTGuard implements Guard
     /**
      * Set the current user.
      *
-     * @param \Illuminate\Contracts\Auth\Authenticatable $user
      * @return $this
      */
     public function setUser(Authenticatable $user)
@@ -405,8 +389,6 @@ class JWTGuard implements Guard
 
     /**
      * Set the current request instance.
-     *
-     * @param Request $request
      *
      * @return $this
      */
@@ -437,7 +419,7 @@ class JWTGuard implements Guard
      */
     protected function hasValidCredentials($user, $credentials)
     {
-        $validated = $user !== null && $this->provider->validateCredentials($user, $credentials);
+        $validated = null !== $user && $this->provider->validateCredentials($user, $credentials);
 
         if ($validated) {
             $this->fireValidatedEvent($user);
@@ -449,7 +431,7 @@ class JWTGuard implements Guard
     /**
      * Ensure the JWTSubject matches what is in the token.
      *
-     * @return  bool
+     * @return bool
      */
     protected function validateSubject()
     {
@@ -466,8 +448,8 @@ class JWTGuard implements Guard
      * Ensure that a token is available in the request.
      *
      * @return JWT
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      *
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
      */
     protected function requireToken()
     {
@@ -480,8 +462,6 @@ class JWTGuard implements Guard
 
     /**
      * Fire the attempt event.
-     *
-     * @param array $credentials
      *
      * @return void
      */
@@ -517,7 +497,6 @@ class JWTGuard implements Guard
      * Fire the failed authentication attempt event.
      *
      * @param Authenticatable|null $user
-     * @param array $credentials
      *
      * @return void
      */
@@ -534,6 +513,7 @@ class JWTGuard implements Guard
      * Fire the authenticated event.
      *
      * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     *
      * @return void
      */
     protected function fireAuthenticatedEvent($user)
@@ -548,7 +528,8 @@ class JWTGuard implements Guard
      * Fire the login event.
      *
      * @param \Illuminate\Contracts\Auth\Authenticatable $user
-     * @param bool $remember
+     * @param bool                                       $remember
+     *
      * @return void
      */
     protected function fireLoginEvent($user, $remember = false)
@@ -564,7 +545,8 @@ class JWTGuard implements Guard
      * Fire the logout event.
      *
      * @param \Illuminate\Contracts\Auth\Authenticatable $user
-     * @param bool $remember
+     * @param bool                                       $remember
+     *
      * @return void
      */
     protected function fireLogoutEvent($user, $remember = false)
@@ -575,16 +557,15 @@ class JWTGuard implements Guard
         ));
     }
 
-
     /**
      * Magically call the JWT instance.
      *
      * @param string $method
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return mixed
-     * @throws BadMethodCallException
      *
+     * @throws BadMethodCallException
      */
     public function __call($method, $parameters)
     {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -63,10 +63,6 @@ class Manager
     /**
      * Constructor.
      *
-     * @param JWTContract $provider
-     * @param Blacklist $blacklist
-     * @param Factory $payloadFactory
-     *
      * @return void
      */
     public function __construct(JWTContract $provider, Blacklist $blacklist, Factory $payloadFactory)
@@ -78,8 +74,6 @@ class Manager
 
     /**
      * Encode a Payload and return the Token.
-     *
-     * @param Payload $payload
      *
      * @return Token
      */
@@ -93,12 +87,11 @@ class Manager
     /**
      * Decode a Token and return the Payload.
      *
-     * @param Token $token
      * @param bool $checkBlacklist
      *
      * @return Payload
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException
      *
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException
      */
     public function decode(Token $token, $checkBlacklist = true)
     {
@@ -126,7 +119,6 @@ class Manager
     /**
      * Refresh a Token and return a new Token.
      *
-     * @param Token $token
      * @param bool $forceForever
      * @param bool $resetClaims
      *
@@ -152,12 +144,11 @@ class Manager
     /**
      * Invalidate a Token by adding it to the blacklist.
      *
-     * @param Token $token
      * @param bool $forceForever
      *
      * @return bool
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     public function invalidate(Token $token, $forceForever = false)
     {
@@ -173,8 +164,6 @@ class Manager
 
     /**
      * Build the claims to go into the refreshed token.
-     *
-     * @param Payload $payload
      *
      * @return array
      */
@@ -267,8 +256,6 @@ class Manager
 
     /**
      * Set the claims to be persisted when refreshing a token.
-     *
-     * @param array $claims
      *
      * @return $this
      */

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -37,8 +37,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Build the Payload.
      *
-     * @param Collection $claims
-     * @param PayloadValidator $validator
      * @param bool $refreshFlow
      *
      * @return void
@@ -61,7 +59,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Checks if a payload matches some expected values.
      *
-     * @param array $values
      * @param bool $strict
      *
      * @return bool
@@ -86,8 +83,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Checks if a payload strictly matches some expected values.
      *
-     * @param array $values
-     *
      * @return bool
      */
     public function matchesStrict(array $values)
@@ -106,7 +101,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     {
         $claim = value($claim);
 
-        if ($claim !== null) {
+        if (null !== $claim) {
             if (is_array($claim)) {
                 return array_map([$this, 'get'], $claim);
             }
@@ -131,8 +126,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
 
     /**
      * Determine whether the payload has the claim (by instance).
-     *
-     * @param Claim $claim
      *
      * @return bool
      */
@@ -240,8 +233,8 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      * @param string $key
      *
      * @return void
-     * @throws PayloadException
      *
+     * @throws PayloadException
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($key)
@@ -276,17 +269,17 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      * Magically get a claim value.
      *
      * @param string $method
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return mixed
-     * @throws BadMethodCallException
      *
+     * @throws BadMethodCallException
      */
     public function __call($method, $parameters)
     {
         if (preg_match('/get(.+)\b/i', $method, $matches)) {
             foreach ($this->claims as $claim) {
-                if (get_class($claim) === 'PHPOpenSourceSaver\\JWTAuth\\Claims\\' . $matches[1]) {
+                if (get_class($claim) === 'PHPOpenSourceSaver\\JWTAuth\\Claims\\'.$matches[1]) {
                     return $claim->getValue();
                 }
             }

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -325,8 +325,8 @@ abstract class AbstractServiceProvider extends ServiceProvider
     /**
      * Helper to get the config values.
      *
-     * @param  string  $key
-     * @param  string  $default
+     * @param string $key
+     * @param string $default
      *
      * @return mixed
      */
@@ -338,7 +338,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     /**
      * Get an instantiable configuration instance.
      *
-     * @param  string  $key
+     * @param string $key
      *
      * @return mixed
      */

--- a/src/Providers/Auth/Illuminate.php
+++ b/src/Providers/Auth/Illuminate.php
@@ -27,8 +27,6 @@ class Illuminate implements Auth
     /**
      * Constructor.
      *
-     * @param GuardContract $auth
-     *
      * @return void
      */
     public function __construct(GuardContract $auth)
@@ -38,8 +36,6 @@ class Illuminate implements Auth
 
     /**
      * Check a user's credentials.
-     *
-     * @param array $credentials
      *
      * @return bool
      */

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -64,10 +64,9 @@ class Lcobucci extends Provider implements JWT
     /**
      * Create the Lcobucci provider.
      *
-     * @param string $secret
-     * @param string $algo
-     * @param array $keys
-     * @param Configuration $config Optional, to pass an existing configuration to be used.
+     * @param string        $secret
+     * @param string        $algo
+     * @param Configuration $config optional, to pass an existing configuration to be used
      *
      * @return void
      */
@@ -125,11 +124,9 @@ class Lcobucci extends Provider implements JWT
     /**
      * Create a JSON Web Token.
      *
-     * @param array $payload
-     *
      * @return string
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     public function encode(array $payload)
     {
@@ -143,7 +140,7 @@ class Lcobucci extends Provider implements JWT
 
             return $this->builder->getToken($this->config->signer(), $this->config->signingKey())->toString();
         } catch (Exception $e) {
-            throw new JWTException('Could not create token: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new JWTException('Could not create token: '.$e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -153,15 +150,15 @@ class Lcobucci extends Provider implements JWT
      * @param string $token
      *
      * @return array
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     public function decode($token)
     {
         try {
             $jwt = $this->config->parser()->parse($token);
         } catch (Exception $e) {
-            throw new TokenInvalidException('Could not decode token: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new TokenInvalidException('Could not decode token: '.$e->getMessage(), $e->getCode(), $e);
         }
 
         if (!$this->config->validator()->validate($jwt, ...$this->config->validationConstraints())) {
@@ -184,7 +181,7 @@ class Lcobucci extends Provider implements JWT
      * Adds a claim to the {@see $config}.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      */
     protected function addClaim($key, $value)
     {
@@ -223,8 +220,8 @@ class Lcobucci extends Provider implements JWT
      * Get the signer instance.
      *
      * @return Signer
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     protected function getSigner()
     {

--- a/src/Providers/JWT/Namshi.php
+++ b/src/Providers/JWT/Namshi.php
@@ -34,10 +34,8 @@ class Namshi extends Provider implements JWT
     /**
      * Constructor.
      *
-     * @param JWS $jws
      * @param string $secret
      * @param string $algo
-     * @param array $keys
      *
      * @return void
      */
@@ -51,20 +49,18 @@ class Namshi extends Provider implements JWT
     /**
      * Create a JSON Web Token.
      *
-     * @param array $payload
-     *
      * @return string
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     public function encode(array $payload)
     {
         try {
             $this->jws->setPayload($payload)->sign($this->getSigningKey(), $this->getPassphrase());
 
-            return (string)$this->jws->getTokenString();
+            return (string) $this->jws->getTokenString();
         } catch (Exception $e) {
-            throw new JWTException('Could not create token: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new JWTException('Could not create token: '.$e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -74,8 +70,8 @@ class Namshi extends Provider implements JWT
      * @param string $token
      *
      * @return array
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     public function decode($token)
     {
@@ -83,14 +79,14 @@ class Namshi extends Provider implements JWT
             // Let's never allow insecure tokens
             $jws = $this->jws->load($token, false);
         } catch (InvalidArgumentException $e) {
-            throw new TokenInvalidException('Could not decode token: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new TokenInvalidException('Could not decode token: '.$e->getMessage(), $e->getCode(), $e);
         }
 
         if (!$jws->verify($this->getVerificationKey(), $this->getAlgo())) {
             throw new TokenInvalidException('Token Signature could not be verified.');
         }
 
-        return (array)$jws->getPayload();
+        return (array) $jws->getPayload();
     }
 
     /**

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -37,7 +37,6 @@ abstract class Provider
      *
      * @param string $secret
      * @param string $algo
-     * @param array $keys
      *
      * @return void
      */
@@ -98,8 +97,6 @@ abstract class Provider
 
     /**
      * Set the keys used to sign the token.
-     *
-     * @param array $keys
      *
      * @return $this
      */
@@ -179,8 +176,8 @@ abstract class Provider
      * requires a public/private key combo.
      *
      * @return bool
-     * @throws JWTException
      *
+     * @throws JWTException
      */
     abstract protected function isAsymmetric();
 }

--- a/src/Providers/Storage/Illuminate.php
+++ b/src/Providers/Storage/Illuminate.php
@@ -14,8 +14,8 @@ namespace PHPOpenSourceSaver\JWTAuth\Providers\Storage;
 
 use BadMethodCallException;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
-use Psr\SimpleCache\CacheInterface as PsrCacheInterface;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage;
+use Psr\SimpleCache\CacheInterface as PsrCacheInterface;
 
 class Illuminate implements Storage
 {
@@ -46,8 +46,6 @@ class Illuminate implements Storage
     /**
      * Constructor.
      *
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     *
      * @return void
      */
     public function __construct(CacheContract $cache)
@@ -58,16 +56,16 @@ class Illuminate implements Storage
     /**
      * Add a new item into storage.
      *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  int  $minutes
+     * @param string $key
+     * @param mixed  $value
+     * @param int    $minutes
      *
      * @return void
      */
     public function add($key, $value, $minutes)
     {
         // If the laravel version is 5.8 or higher then convert minutes to seconds.
-        if ($this->laravelVersion !== null
+        if (null !== $this->laravelVersion
             && is_int($minutes)
             && version_compare($this->laravelVersion, '5.8', '>=')
         ) {
@@ -80,8 +78,8 @@ class Illuminate implements Storage
     /**
      * Add a new item into storage forever.
      *
-     * @param  string  $key
-     * @param  mixed  $value
+     * @param string $key
+     * @param mixed  $value
      *
      * @return void
      */
@@ -93,7 +91,7 @@ class Illuminate implements Storage
     /**
      * Get an item from storage.
      *
-     * @param  string  $key
+     * @param string $key
      *
      * @return mixed
      */
@@ -105,7 +103,7 @@ class Illuminate implements Storage
     /**
      * Remove an item from storage.
      *
-     * @param  string  $key
+     * @param string $key
      *
      * @return bool
      */
@@ -131,7 +129,7 @@ class Illuminate implements Storage
      */
     protected function cache()
     {
-        if ($this->supportsTags === null) {
+        if (null === $this->supportsTags) {
             $this->determineTagSupport();
         }
 

--- a/src/Support/CustomClaims.php
+++ b/src/Support/CustomClaims.php
@@ -24,8 +24,6 @@ trait CustomClaims
     /**
      * Set the custom claims.
      *
-     * @param array $customClaims
-     *
      * @return $this
      */
     public function customClaims(array $customClaims)
@@ -37,8 +35,6 @@ trait CustomClaims
 
     /**
      * Alias to set the custom claims.
-     *
-     * @param array $customClaims
      *
      * @return $this
      */

--- a/src/Token.php
+++ b/src/Token.php
@@ -24,11 +24,12 @@ class Token
      * @param string $value
      *
      * @return void
+     *
      * @throws Exceptions\TokenInvalidException
      */
     public function __construct($value)
     {
-        $this->value = (string)(new TokenValidator())->check($value);
+        $this->value = (string) (new TokenValidator())->check($value);
     }
 
     /**

--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -56,11 +56,9 @@ class PayloadValidator extends Validator
      * Ensure the payload contains the required claims and
      * the claims have the relevant type.
      *
-     * @param Collection $claims
-     *
      * @return void
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
      *
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
      */
     protected function validateStructure(Collection $claims)
     {
@@ -72,11 +70,9 @@ class PayloadValidator extends Validator
     /**
      * Validate the payload timestamps.
      *
-     * @param Collection $claims
-     *
      * @return Collection
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
      *
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
      * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException
      */
     protected function validatePayload(Collection $claims)
@@ -87,21 +83,17 @@ class PayloadValidator extends Validator
     /**
      * Check the token in the refresh flow context.
      *
-     * @param Collection $claims
-     *
      * @return Collection
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException
      *
+     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException
      */
     protected function validateRefresh(Collection $claims)
     {
-        return $this->refreshTTL === null ? $claims : $claims->validate('refresh', $this->refreshTTL);
+        return null === $this->refreshTTL ? $claims : $claims->validate('refresh', $this->refreshTTL);
     }
 
     /**
      * Set the required claims.
-     *
-     * @param array $claims
      *
      * @return $this
      */

--- a/src/Validators/TokenValidator.php
+++ b/src/Validators/TokenValidator.php
@@ -22,6 +22,7 @@ class TokenValidator extends Validator
      * @param string $value
      *
      * @return string
+     *
      * @throws TokenInvalidException
      */
     public function check($value)
@@ -33,20 +34,20 @@ class TokenValidator extends Validator
      * @param string $token
      *
      * @return string
-     * @throws TokenInvalidException
      *
+     * @throws TokenInvalidException
      */
     protected function validateStructure($token)
     {
         $parts = explode('.', $token);
 
-        if (count($parts) !== 3) {
+        if (3 !== count($parts)) {
             throw new TokenInvalidException('Wrong number of segments');
         }
 
         $parts = array_filter(array_map('trim', $parts));
 
-        if (count($parts) !== 3 || implode('.', $parts) !== $token) {
+        if (3 !== count($parts) || implode('.', $parts) !== $token) {
             throw new TokenInvalidException('Malformed token');
         }
 

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -14,7 +14,6 @@ namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
@@ -26,7 +25,6 @@ use PHPOpenSourceSaver\JWTAuth\Claims\Subject;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage;
 use PHPOpenSourceSaver\JWTAuth\Payload;
 use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
-use PHPOpenSourceSaver\JWTAuth\Validators\Validator;
 
 class BlacklistTest extends AbstractTestCase
 {
@@ -46,7 +44,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_add_a_valid_token_to_the_blacklist()
+    public function itShouldAddAValidTokenToTheBlacklist()
     {
         $claims = [
             new Subject(1),
@@ -78,7 +76,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_add_a_token_with_no_exp_to_the_blacklist_forever()
+    public function itShouldAddATokenWithNoExpToTheBlacklistForever()
     {
         $claims = [
             new Subject(1),
@@ -98,7 +96,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_true_when_adding_an_expired_token_to_the_blacklist()
+    public function itShouldReturnTrueWhenAddingAnExpiredTokenToTheBlacklist()
     {
         $claims = [
             new Subject(1),
@@ -129,7 +127,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_true_early_when_adding_an_item_and_it_already_exists()
+    public function itShouldReturnTrueEarlyWhenAddingAnItemAndItAlreadyExists()
     {
         $claims = [
             new Subject(1),
@@ -160,7 +158,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_check_whether_a_token_has_been_blacklisted()
+    public function itShouldCheckWhetherATokenHasBeenBlacklisted()
     {
         $claims = [
             new Subject(1),
@@ -199,7 +197,7 @@ class BlacklistTest extends AbstractTestCase
      *
      * @param mixed $result
      */
-    public function it_should_check_whether_a_token_has_not_been_blacklisted($result)
+    public function itShouldCheckWhetherATokenHasNotBeenBlacklisted($result)
     {
         $claims = [
             new Subject(1),
@@ -221,7 +219,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_check_whether_a_token_has_been_blacklisted_forever()
+    public function itShouldCheckWhetherATokenHasBeenBlacklistedForever()
     {
         $claims = [
             new Subject(1),
@@ -243,7 +241,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_check_whether_a_token_has_been_blacklisted_when_the_token_is_not_blacklisted()
+    public function itShouldCheckWhetherATokenHasBeenBlacklistedWhenTheTokenIsNotBlacklisted()
     {
         $claims = [
             new Subject(1),
@@ -265,7 +263,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_remove_a_token_from_the_blacklist()
+    public function itShouldRemoveATokenFromTheBlacklist()
     {
         $claims = [
             new Subject(1),
@@ -286,7 +284,7 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_set_a_custom_unique_key_for_the_blacklist()
+    public function itShouldSetACustomUniqueKeyForTheBlacklist()
     {
         $claims = [
             new Subject(1),
@@ -309,21 +307,21 @@ class BlacklistTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_empty_the_blacklist()
+    public function itShouldEmptyTheBlacklist()
     {
         $this->storage->shouldReceive('flush');
         $this->assertTrue($this->blacklist->clear());
     }
 
     /** @test */
-    public function it_should_set_and_get_the_blacklist_grace_period()
+    public function itShouldSetAndGetTheBlacklistGracePeriod()
     {
         $this->assertInstanceOf(Blacklist::class, $this->blacklist->setGracePeriod(15));
         $this->assertSame(15, $this->blacklist->getGracePeriod());
     }
 
     /** @test */
-    public function it_should_set_and_get_the_blacklist_refresh_ttl()
+    public function itShouldSetAndGetTheBlacklistRefreshTtl()
     {
         $this->assertInstanceOf(Blacklist::class, $this->blacklist->setRefreshTTL(15));
         $this->assertSame(15, $this->blacklist->getRefreshTTL());

--- a/tests/Claims/ClaimTest.php
+++ b/tests/Claims/ClaimTest.php
@@ -32,7 +32,7 @@ class ClaimTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_passing_an_invalid_value()
+    public function itShouldThrowAnExceptionWhenPassingAnInvalidValue()
     {
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('Invalid value provided for claim [exp]');
@@ -41,25 +41,25 @@ class ClaimTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_convert_the_claim_to_an_array()
+    public function itShouldConvertTheClaimToAnArray()
     {
         $this->assertSame(['exp' => $this->testNowTimestamp], $this->claim->toArray());
     }
 
     /** @test */
-    public function it_should_get_the_claim_as_a_string()
+    public function itShouldGetTheClaimAsAString()
     {
-        $this->assertJsonStringEqualsJsonString((string)$this->claim, $this->claim->toJson());
+        $this->assertJsonStringEqualsJsonString((string) $this->claim, $this->claim->toJson());
     }
 
     /** @test */
-    public function it_should_get_the_object_as_json()
+    public function itShouldGetTheObjectAsJson()
     {
         $this->assertJsonStringEqualsJsonString(json_encode($this->claim), $this->claim->toJson());
     }
 
     /** @test */
-    public function it_should_implement_arrayable()
+    public function itShouldImplementArrayable()
     {
         $this->assertInstanceOf(Arrayable::class, $this->claim);
     }

--- a/tests/Claims/CollectionTest.php
+++ b/tests/Claims/CollectionTest.php
@@ -24,7 +24,7 @@ use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 class CollectionTest extends AbstractTestCase
 {
     /** @test */
-    public function it_should_sanitize_the_claims_to_associative_array()
+    public function itShouldSanitizeTheClaimsToAssociativeArray()
     {
         $collection = $this->getCollection();
 
@@ -46,7 +46,7 @@ class CollectionTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_determine_if_a_collection_contains_all_the_given_claims()
+    public function itShouldDetermineIfACollectionContainsAllTheGivenClaims()
     {
         $collection = $this->getCollection();
 
@@ -59,7 +59,7 @@ class CollectionTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_a_claim_instance_by_name()
+    public function itShouldGetAClaimInstanceByName()
     {
         $collection = $this->getCollection();
 

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -19,7 +19,6 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Mockery;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
 use PHPOpenSourceSaver\JWTAuth\Claims\IssuedAt;
@@ -61,7 +60,7 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_handle_carbon_claims()
+    public function itShouldHandleCarbonClaims()
     {
         $testCarbon = Carbon::createFromTimestampUTC($this->testNowTimestamp);
         $testCarbonCopy = clone $testCarbon;
@@ -86,7 +85,7 @@ class DatetimeClaimTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_handle_datetime_claims()
+    public function itShouldHandleDatetimeClaims()
     {
         $testDateTime = DateTime::createFromFormat('U', $this->testNowTimestamp);
         $testDateTimeCopy = clone $testDateTime;
@@ -110,9 +109,9 @@ class DatetimeClaimTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_handle_datetime_immutable_claims()
+    public function itShouldHandleDatetimeImmutableClaims()
     {
-        $testDateTimeImmutable = DateTimeImmutable::createFromFormat('U', (string)$this->testNowTimestamp);
+        $testDateTimeImmutable = DateTimeImmutable::createFromFormat('U', (string) $this->testNowTimestamp);
 
         $this->assertInstanceOf(DateTimeImmutable::class, $testDateTimeImmutable);
         $this->assertInstanceOf(DatetimeInterface::class, $testDateTimeImmutable);
@@ -135,7 +134,7 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_handle_datetinterval_claims()
+    public function itShouldHandleDatetintervalClaims()
     {
         $testDateInterval = new DateInterval('PT1H');
 

--- a/tests/Claims/FactoryTest.php
+++ b/tests/Claims/FactoryTest.php
@@ -36,27 +36,27 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_set_the_request()
+    public function itShouldSetTheRequest()
     {
         $factory = $this->factory->setRequest(Request::create('/bar', 'GET'));
         $this->assertInstanceOf(Factory::class, $factory);
     }
 
     /** @test */
-    public function it_should_set_the_ttl()
+    public function itShouldSetTheTtl()
     {
         $this->assertInstanceOf(Factory::class, $this->factory->setTTL(30));
     }
 
     /** @test */
-    public function it_should_get_the_ttl()
+    public function itShouldGetTheTtl()
     {
         $this->factory->setTTL($ttl = 30);
         $this->assertSame($ttl, $this->factory->getTTL());
     }
 
     /** @test */
-    public function it_should_get_a_defined_claim_instance_when_passing_a_name_and_value()
+    public function itShouldGetADefinedClaimInstanceWhenPassingANameAndValue()
     {
         $this->assertInstanceOf(Subject::class, $this->factory->get('sub', 1));
         $this->assertInstanceOf(Issuer::class, $this->factory->get('iss', 'http://example.com'));
@@ -67,13 +67,13 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_a_custom_claim_instance_when_passing_a_non_defined_name_and_value()
+    public function itShouldGetACustomClaimInstanceWhenPassingANonDefinedNameAndValue()
     {
         $this->assertInstanceOf(Custom::class, $this->factory->get('foo', ['bar']));
     }
 
     /** @test */
-    public function it_should_make_a_claim_instance_with_a_value()
+    public function itShouldMakeAClaimInstanceWithAValue()
     {
         $iat = $this->factory->make('iat');
         $this->assertSame($iat->getValue(), $this->testNowTimestamp);
@@ -96,7 +96,7 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_extend_claim_factory_to_add_a_custom_claim()
+    public function itShouldExtendClaimFactoryToAddACustomClaim()
     {
         $this->factory->extend('foo', Foo::class);
 

--- a/tests/Claims/IssuedAtTest.php
+++ b/tests/Claims/IssuedAtTest.php
@@ -19,7 +19,7 @@ use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 class IssuedAtTest extends AbstractTestCase
 {
     /** @test */
-    public function it_should_throw_an_exception_when_passing_a_future_timestamp()
+    public function itShouldThrowAnExceptionWhenPassingAFutureTimestamp()
     {
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('Invalid value provided for claim [iat]');

--- a/tests/Claims/NotBeforeTest.php
+++ b/tests/Claims/NotBeforeTest.php
@@ -19,7 +19,7 @@ use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 class NotBeforeTest extends AbstractTestCase
 {
     /** @test */
-    public function it_should_throw_an_exception_when_passing_an_invalid_value()
+    public function itShouldThrowAnExceptionWhenPassingAnInvalidValue()
     {
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('Invalid value provided for claim [nbf]');

--- a/tests/DefaultConfigValuesTest.php
+++ b/tests/DefaultConfigValuesTest.php
@@ -24,17 +24,17 @@ class DefaultConfigValuesTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->configuration = include __DIR__ . '/../config/config.php';
+        $this->configuration = include __DIR__.'/../config/config.php';
     }
 
     /** @test */
-    public function secret_should_be_null()
+    public function secretShouldBeNull()
     {
         $this->assertNull($this->configuration['secret']);
     }
 
     /** @test */
-    public function keys_should_be_null()
+    public function keysShouldBeNull()
     {
         $this->assertNull($this->configuration['keys']['public']);
         $this->assertNull($this->configuration['keys']['private']);
@@ -42,25 +42,25 @@ class DefaultConfigValuesTest extends AbstractTestCase
     }
 
     /** @test */
-    public function ttl_should_be_set()
+    public function ttlShouldBeSet()
     {
         $this->assertEquals(60, $this->configuration['ttl']);
     }
 
     /** @test */
-    public function refresh_ttl_should_be_set()
+    public function refreshTtlShouldBeSet()
     {
         $this->assertEquals(20160, $this->configuration['refresh_ttl']);
     }
 
     /** @test */
-    public function algo_should_be_hs256()
+    public function algoShouldBeHs256()
     {
         $this->assertEquals('HS256', $this->configuration['algo']);
     }
 
     /** @test */
-    public function required_claims_should_be_set()
+    public function requiredClaimsShouldBeSet()
     {
         $this->assertIsArray($this->configuration['required_claims']);
         $this->assertCount(6, $this->configuration['required_claims']);
@@ -74,50 +74,50 @@ class DefaultConfigValuesTest extends AbstractTestCase
     }
 
     /** @test */
-    public function persisted_claims_should_be_empty()
+    public function persistedClaimsShouldBeEmpty()
     {
         $this->assertIsArray($this->configuration['persistent_claims']);
         $this->assertCount(0, $this->configuration['persistent_claims']);
     }
 
     /** @test */
-    public function subject_should_be_locked()
+    public function subjectShouldBeLocked()
     {
         $this->assertTrue($this->configuration['lock_subject']);
     }
 
     /** @test */
-    public function leeway_should_be_set()
+    public function leewayShouldBeSet()
     {
         $this->assertEquals(0, $this->configuration['leeway']);
     }
 
     /** @test */
-    public function blacklist_should_be_enabled()
+    public function blacklistShouldBeEnabled()
     {
         $this->assertTrue($this->configuration['blacklist_enabled']);
     }
 
     /** @test */
-    public function blacklist_grace_period_should_be_set()
+    public function blacklistGracePeriodShouldBeSet()
     {
         $this->assertEquals(0, $this->configuration['blacklist_grace_period']);
     }
 
     /** @test */
-    public function show_black_list_exception_should_be_disabled()
+    public function showBlackListExceptionShouldBeDisabled()
     {
         $this->assertEquals(0, $this->configuration['show_black_list_exception']);
     }
 
     /** @test */
-    public function decrypt_cookies_should_be_disabled()
+    public function decryptCookiesShouldBeDisabled()
     {
         $this->assertFalse($this->configuration['decrypt_cookies']);
     }
 
     /** @test */
-    public function providers_should_be_set()
+    public function providersShouldBeSet()
     {
         $this->assertEquals(Lcobucci::class, $this->configuration['providers']['jwt']);
         $this->assertEquals(AuthIlluminate::class, $this->configuration['providers']['auth']);

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -14,7 +14,6 @@ namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Custom;
 use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
@@ -47,7 +46,7 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_a_payload_when_passing_an_array_of_claims()
+    public function itShouldReturnAPayloadWhenPassingAnArrayOfClaims()
     {
         $expTime = $this->testNowTimestamp + 3600;
 
@@ -90,7 +89,7 @@ class FactoryTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_return_a_payload_when_chaining_claim_methods()
+    public function itShouldReturnAPayloadWhenChainingClaimMethods()
     {
         $this->claimFactory->shouldReceive('get')->twice()->with('sub', 1)->andReturn(new Subject(1));
         $this->claimFactory->shouldReceive('get')->twice()->with('foo', 'baz')->andReturn(new Custom('foo', 'baz'));
@@ -121,7 +120,7 @@ class FactoryTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_return_a_payload_when_passing_miltidimensional_array_as_custom_claim_to_make_method()
+    public function itShouldReturnAPayloadWhenPassingMiltidimensionalArrayAsCustomClaimToMakeMethod()
     {
         // these are added from default claims
         $this->claimFactory->shouldReceive('make')->twice()->with('iss')->andReturn(new Issuer('/foo'));
@@ -155,7 +154,7 @@ class FactoryTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_exclude_the_exp_claim_when_setting_ttl_to_null()
+    public function itShouldExcludeTheExpClaimWhenSettingTtlToNull()
     {
         // these are added from default claims
         $this->claimFactory->shouldReceive('make')->twice()->with('iss')->andReturn(new Issuer('/foo'));
@@ -183,7 +182,7 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_exclude_claims_from_previous_payloads()
+    public function itShouldExcludeClaimsFromPreviousPayloads()
     {
         $validator = new PayloadValidator();
         $factory = new Factory($this->claimFactory, $validator);
@@ -212,7 +211,7 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_set_the_default_claims()
+    public function itShouldSetTheDefaultClaims()
     {
         $this->factory->setDefaultClaims(['sub', 'iat']);
 
@@ -222,7 +221,7 @@ class FactoryTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_get_payload_with_a_predefined_collection_of_claims()
+    public function itShouldGetPayloadWithAPredefinedCollectionOfClaims()
     {
         $claims = [
             new Subject(1),
@@ -243,7 +242,7 @@ class FactoryTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_validator()
+    public function itShouldGetTheValidator()
     {
         $this->assertInstanceOf(PayloadValidator::class, $this->factory->validator());
     }

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -31,7 +31,7 @@ use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 class ParserTest extends AbstractTestCase
 {
     /** @test */
-    public function it_should_return_the_token_from_the_authorization_header()
+    public function itShouldReturnTheTokenFromTheAuthorizationHeader()
     {
         $request = Request::create('foo', 'POST');
         $request->headers->set('Authorization', 'Bearer foobar');
@@ -50,7 +50,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_the_prefixed_authentication_header()
+    public function itShouldReturnTheTokenFromThePrefixedAuthenticationHeader()
     {
         $request = Request::create('foo', 'POST');
         $request->headers->set('Authorization', 'Custom foobar');
@@ -69,7 +69,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_the_custom_authentication_header()
+    public function itShouldReturnTheTokenFromTheCustomAuthenticationHeader()
     {
         $request = Request::create('foo', 'POST');
         $request->headers->set('custom_authorization', 'Bearer foobar');
@@ -88,7 +88,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_the_alt_authorization_headers()
+    public function itShouldReturnTheTokenFromTheAltAuthorizationHeaders()
     {
         $request1 = Request::create('foo', 'POST');
         $request1->server->set('HTTP_AUTHORIZATION', 'Bearer foobar');
@@ -112,7 +112,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_not_strip_trailing_hyphens_from_the_authorization_header()
+    public function itShouldNotStripTrailingHyphensFromTheAuthorizationHeader()
     {
         $request = Request::create('foo', 'POST');
         $request->headers->set('Authorization', 'Bearer foobar--');
@@ -134,7 +134,7 @@ class ParserTest extends AbstractTestCase
      * @test
      * @dataProvider whitespaceProvider
      */
-    public function it_should_handle_excess_whitespace_from_the_authorization_header($whitespace)
+    public function itShouldHandleExcessWhitespaceFromTheAuthorizationHeader($whitespace)
     {
         $request = Request::create('foo', 'POST');
         $request->headers->set('Authorization', "Bearer{$whitespace}foobar{$whitespace}");
@@ -168,7 +168,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_query_string()
+    public function itShouldReturnTheTokenFromQueryString()
     {
         $request = Request::create('foo', 'GET', ['token' => 'foobar']);
 
@@ -185,7 +185,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_the_custom_query_string()
+    public function itShouldReturnTheTokenFromTheCustomQueryString()
     {
         $request = Request::create('foo', 'GET', ['custom_token_key' => 'foobar']);
 
@@ -202,7 +202,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_the_query_string_not_the_input_source()
+    public function itShouldReturnTheTokenFromTheQueryStringNotTheInputSource()
     {
         $request = Request::create('foo?token=foobar', 'POST', [], [], [], [], json_encode(['token' => 'foobarbaz']));
 
@@ -219,7 +219,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_the_custom_query_string_not_the_custom_input_source()
+    public function itShouldReturnTheTokenFromTheCustomQueryStringNotTheCustomInputSource()
     {
         $request = Request::create('foo?custom_token_key=foobar', 'POST', [], [], [], [], json_encode(['custom_token_key' => 'foobarbaz']));
 
@@ -236,7 +236,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_input_source()
+    public function itShouldReturnTheTokenFromInputSource()
     {
         $request = Request::create('foo', 'POST', [], [], [], [], json_encode(['token' => 'foobar']));
         $request->headers->set('Content-Type', 'application/json');
@@ -254,7 +254,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_the_custom_input_source()
+    public function itShouldReturnTheTokenFromTheCustomInputSource()
     {
         $request = Request::create('foo', 'POST', [], [], [], [], json_encode(['custom_token_key' => 'foobar']));
         $request->headers->set('Content-Type', 'application/json');
@@ -272,7 +272,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_an_unencrypted_cookie()
+    public function itShouldReturnTheTokenFromAnUnencryptedCookie()
     {
         $request = Request::create('foo', 'POST', [], ['token' => 'foobar']);
 
@@ -290,7 +290,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_a_crypted_cookie()
+    public function itShouldReturnTheTokenFromACryptedCookie()
     {
         Crypt::shouldReceive('encrypt')
             ->with('foobar')
@@ -318,7 +318,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_token_invalid_exception_from_a_invalid_encrypted_cookie()
+    public function itShouldThrowTokenInvalidExceptionFromAInvalidEncryptedCookie()
     {
         $request = Request::create('foo', 'POST', [], ['token' => 'foobar']);
 
@@ -341,7 +341,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_route()
+    public function itShouldReturnTheTokenFromRoute()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
         $request->setRouteResolver(fn () => $this->getRouteMock('foobar'));
@@ -368,7 +368,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_from_route_with_a_custom_param()
+    public function itShouldReturnTheTokenFromRouteWithACustomParam()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
         $request->setRouteResolver(fn () => $this->getRouteMock('foobar', 'custom_route_param'));
@@ -386,11 +386,10 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_ignore_routeless_requests()
+    public function itShouldIgnoreRoutelessRequests()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
         $request->setRouteResolver(function () {
-            //
         });
 
         $parser = new Parser($request);
@@ -406,7 +405,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_ignore_lumen_request_arrays()
+    public function itShouldIgnoreLumenRequestArrays()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
         $request->setRouteResolver(fn () => [false, ['uses' => 'someController'], ['token' => 'foobar']]);
@@ -424,7 +423,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_accept_lumen_request_arrays_with_special_class()
+    public function itShouldAcceptLumenRequestArraysWithSpecialClass()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
         $request->setRouteResolver(fn () => [false, ['uses' => 'someController'], ['token' => 'foo.bar.baz']]);
@@ -442,7 +441,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_null_if_no_token_in_request()
+    public function itShouldReturnNullIfNoTokenInRequest()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
         $request->setRouteResolver(fn () => $this->getRouteMock());
@@ -460,7 +459,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_retrieve_the_chain()
+    public function itShouldRetrieveTheChain()
     {
         $chain = [
             new AuthHeaders(),
@@ -476,7 +475,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_retrieve_the_chain_with_alias()
+    public function itShouldRetrieveTheChainWithAlias()
     {
         $chain = [
             new AuthHeaders(),
@@ -495,14 +494,14 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_set_the_cookie_key()
+    public function itShouldSetTheCookieKey()
     {
         $cookies = (new Cookies())->setKey('test');
         $this->assertInstanceOf(Cookies::class, $cookies);
     }
 
     /** @test */
-    public function it_should_add_custom_parser()
+    public function itShouldAddCustomParser()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
 
@@ -517,7 +516,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_add_multiple_custom_parser()
+    public function itShouldAddMultipleCustomParser()
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
 

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -15,7 +15,6 @@ namespace PHPOpenSourceSaver\JWTAuth\Test;
 use Illuminate\Http\Request;
 use Mockery;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
@@ -47,7 +46,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_a_token_when_passing_a_user()
+    public function itShouldReturnATokenWhenPassingAUser()
     {
         $payloadFactory = Mockery::mock(Factory::class);
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
@@ -66,7 +65,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_pass_provider_check_if_hash_matches()
+    public function itShouldPassProviderCheckIfHashMatches()
     {
         $payloadFactory = Mockery::mock(Factory::class);
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
@@ -80,7 +79,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_pass_provider_check_if_hash_matches_when_provider_is_null()
+    public function itShouldPassProviderCheckIfHashMatchesWhenProviderIsNull()
     {
         $payloadFactory = Mockery::mock(Factory::class);
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
@@ -94,7 +93,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_not_pass_provider_check_if_hash_not_match()
+    public function itShouldNotPassProviderCheckIfHashNotMatch()
     {
         $payloadFactory = Mockery::mock(Factory::class);
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
@@ -108,7 +107,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_a_token_when_passing_valid_credentials_to_attempt_method()
+    public function itShouldReturnATokenWhenPassingValidCredentialsToAttemptMethod()
     {
         $payloadFactory = Mockery::mock(Factory::class);
         $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
@@ -130,7 +129,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_false_when_passing_invalid_credentials_to_attempt_method()
+    public function itShouldReturnFalseWhenPassingInvalidCredentialsToAttemptMethod()
     {
         $this->manager->shouldReceive('encode->get')->never();
         $this->auth->shouldReceive('byCredentials')->once()->andReturn(false);
@@ -142,7 +141,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_not_providing_a_token()
+    public function itShouldThrowAnExceptionWhenNotProvidingAToken()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('A token is required');
@@ -151,7 +150,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_owning_user_from_a_token_containing_an_existing_user()
+    public function itShouldReturnTheOwningUserFromATokenContainingAnExistingUser()
     {
         $payload = Mockery::mock(Payload::class);
         $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);
@@ -159,7 +158,7 @@ class JWTAuthTest extends AbstractTestCase
         $this->manager->shouldReceive('decode')->once()->andReturn($payload);
 
         $this->auth->shouldReceive('byId')->once()->with(1)->andReturn(true);
-        $this->auth->shouldReceive('user')->once()->andReturn((object)['id' => 1]);
+        $this->auth->shouldReceive('user')->once()->andReturn((object) ['id' => 1]);
 
         $user = $this->jwtAuth->setToken('foo.bar.baz')->customClaims(['foo' => 'bar'])->authenticate();
 
@@ -167,7 +166,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_false_when_passing_a_token_not_containing_an_existing_user()
+    public function itShouldReturnFalseWhenPassingATokenNotContainingAnExistingUser()
     {
         $payload = Mockery::mock(Payload::class);
         $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);
@@ -183,7 +182,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_refresh_a_token()
+    public function itShouldRefreshAToken()
     {
         $newToken = Mockery::mock(Token::class);
         $newToken->shouldReceive('get')->once()->andReturn('baz.bar.foo');
@@ -196,7 +195,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_invalidate_a_token()
+    public function itShouldInvalidateAToken()
     {
         $token = new Token('foo.bar.baz');
 
@@ -206,7 +205,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_force_invalidate_a_token_forever()
+    public function itShouldForceInvalidateATokenForever()
     {
         $token = new Token('foo.bar.baz');
 
@@ -216,7 +215,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_retrieve_the_token_from_the_request()
+    public function itShouldRetrieveTheTokenFromTheRequest()
     {
         $this->parser->shouldReceive('parseToken')->andReturn('foo.bar.baz');
 
@@ -225,14 +224,14 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_authenticated_user()
+    public function itShouldGetTheAuthenticatedUser()
     {
         $manager = $this->jwtAuth->manager();
         $this->assertInstanceOf(Manager::class, $manager);
     }
 
     /** @test */
-    public function it_should_return_false_if_the_token_is_invalid()
+    public function itShouldReturnFalseIfTheTokenIsInvalid()
     {
         $this->parser->shouldReceive('parseToken')->andReturn('foo.bar.baz');
         $this->manager->shouldReceive('decode')->once()->andThrow(new TokenInvalidException());
@@ -241,7 +240,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_true_if_the_token_is_valid()
+    public function itShouldReturnTrueIfTheTokenIsValid()
     {
         $payload = Mockery::mock(Payload::class);
 
@@ -252,7 +251,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_token_not_present_in_request()
+    public function itShouldThrowAnExceptionWhenTokenNotPresentInRequest()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('The token could not be parsed from the request');
@@ -263,7 +262,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_false_when_no_token_is_set()
+    public function itShouldReturnFalseWhenNoTokenIsSet()
     {
         $this->parser->shouldReceive('parseToken')->andReturn(false);
 
@@ -271,7 +270,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_magically_call_the_manager()
+    public function itShouldMagicallyCallTheManager()
     {
         $this->manager->shouldReceive('getBlacklist')->andReturn(new stdClass());
 
@@ -281,7 +280,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_set_the_request()
+    public function itShouldSetTheRequest()
     {
         $request = Request::create('/foo', 'GET', ['token' => 'some.random.token']);
 
@@ -294,7 +293,7 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_unset_the_token()
+    public function itShouldUnsetTheToken()
     {
         $this->parser->shouldReceive('parseToken')->andThrow(new JWTException());
         $token = new Token('foo.bar.baz');
@@ -306,21 +305,21 @@ class JWTAuthTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_manager_instance()
+    public function itShouldGetTheManagerInstance()
     {
         $manager = $this->jwtAuth->manager();
         $this->assertInstanceOf(Manager::class, $manager);
     }
 
     /** @test */
-    public function it_should_get_the_parser_instance()
+    public function itShouldGetTheParserInstance()
     {
         $parser = $this->jwtAuth->parser();
         $this->assertInstanceOf(Parser::class, $parser);
     }
 
     /** @test */
-    public function it_should_get_a_claim_value()
+    public function itShouldGetAClaimValue()
     {
         $payload = Mockery::mock(Payload::class);
         $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -18,7 +18,6 @@ use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
-use Illuminate\Auth\Events\Validated;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Mockery;

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -20,11 +20,9 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\Validated;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
 use Mockery;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException;
 use PHPOpenSourceSaver\JWTAuth\Factory;
@@ -59,13 +57,13 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_request()
+    public function itShouldGetTheRequest()
     {
         $this->assertInstanceOf(Request::class, $this->guard->getRequest());
     }
 
     /** @test */
-    public function it_should_get_the_authenticated_user_if_a_valid_token_is_provided()
+    public function itShouldGetTheAuthenticatedUserIfAValidTokenIsProvided()
     {
         $payload = Mockery::mock(Payload::class);
         $payload->shouldReceive('offsetGet')->once()->with('sub')->andReturn(1);
@@ -84,7 +82,7 @@ class JWTGuardTest extends AbstractTestCase
         $this->provider->shouldReceive('retrieveById')
             ->once()
             ->with(1)
-            ->andReturn((object)['id' => 1]);
+            ->andReturn((object) ['id' => 1]);
 
         $this->assertSame(1, $this->guard->user()->id);
 
@@ -97,7 +95,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_authenticated_user_if_a_valid_token_is_provided_and_not_throw_an_exception()
+    public function itShouldGetTheAuthenticatedUserIfAValidTokenIsProvidedAndNotThrowAnException()
     {
         $payload = Mockery::mock(Payload::class);
         $payload->shouldReceive('offsetGet')->once()->with('sub')->andReturn(1);
@@ -116,7 +114,7 @@ class JWTGuardTest extends AbstractTestCase
         $this->provider->shouldReceive('retrieveById')
             ->once()
             ->with(1)
-            ->andReturn((object)['id' => 1]);
+            ->andReturn((object) ['id' => 1]);
 
         $this->assertSame(1, $this->guard->userOrFail()->id);
 
@@ -126,7 +124,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_null_if_an_invalid_token_is_provided()
+    public function itShouldReturnNullIfAnInvalidTokenIsProvided()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
         $this->jwt->shouldReceive('getToken')->twice()->andReturn('invalid.token.here');
@@ -139,7 +137,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_null_if_no_token_is_provided()
+    public function itShouldReturnNullIfNoTokenIsProvided()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
         $this->jwt->shouldReceive('getToken')->andReturn(false);
@@ -152,7 +150,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_if_an_invalid_token_is_provided()
+    public function itShouldThrowAnExceptionIfAnInvalidTokenIsProvided()
     {
         $this->expectException(UserNotDefinedException::class);
         $this->expectExceptionMessage('An error occurred');
@@ -168,7 +166,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_if_no_token_is_provided()
+    public function itShouldThrowAnExceptionIfNoTokenIsProvided()
     {
         $this->expectException(UserNotDefinedException::class);
         $this->expectExceptionMessage('An error occurred');
@@ -184,7 +182,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_a_token_if_credentials_are_ok_and_user_is_found()
+    public function itShouldReturnATokenIfCredentialsAreOkAndUserIsFound()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
         $user = new LaravelUserStub();
@@ -239,7 +237,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_true_if_credentials_are_ok_and_user_is_found_when_choosing_not_to_login()
+    public function itShouldReturnTrueIfCredentialsAreOkAndUserIsFoundWhenChoosingNotToLogin()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
         $user = new LaravelUserStub();
@@ -277,7 +275,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_false_if_credentials_are_invalid()
+    public function itShouldReturnFalseIfCredentialsAreInvalid()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
         $user = new LaravelUserStub();
@@ -312,14 +310,14 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_magically_call_the_jwt_instance()
+    public function itShouldMagicallyCallTheJwtInstance()
     {
         $this->jwt->shouldReceive('factory')->andReturn(Mockery::mock(Factory::class));
         $this->assertInstanceOf(Factory::class, $this->guard->factory());
     }
 
     /** @test */
-    public function it_should_logout_the_user_by_invalidating_the_token()
+    public function itShouldLogoutTheUserByInvalidatingTheToken()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
         $this->jwt->shouldReceive('getToken')->once()->andReturn(true);
@@ -339,7 +337,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_refresh_the_token()
+    public function itShouldRefreshTheToken()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
         $this->jwt->shouldReceive('getToken')->once()->andReturn(true);
@@ -349,7 +347,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_invalidate_the_token()
+    public function itShouldInvalidateTheToken()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
         $this->jwt->shouldReceive('getToken')->once()->andReturn(true);
@@ -359,7 +357,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_if_there_is_no_token_present_when_required()
+    public function itShouldThrowAnExceptionIfThereIsNoTokenPresentWhenRequired()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('Token could not be parsed from the request.');
@@ -372,7 +370,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_generate_a_token_by_id()
+    public function itShouldGenerateATokenById()
     {
         $user = new LaravelUserStub();
 
@@ -398,7 +396,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_not_generate_a_token_by_id()
+    public function itShouldNotGenerateATokenById()
     {
         $this->provider->shouldReceive('retrieveById')
             ->once()
@@ -409,7 +407,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_authenticate_the_user_by_credentials_and_return_true_if_valid()
+    public function itShouldAuthenticateTheUserByCredentialsAndReturnTrueIfValid()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
         $user = new LaravelUserStub();
@@ -446,7 +444,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_attempt_to_authenticate_the_user_by_credentials_and_return_false_if_invalid()
+    public function itShouldAttemptToAuthenticateTheUserByCredentialsAndReturnFalseIfInvalid()
     {
         $credentials = ['foo' => 'bar', 'baz' => 'bob'];
         $user = new LaravelUserStub();
@@ -473,7 +471,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_authenticate_the_user_by_id_and_return_boolean()
+    public function itShouldAuthenticateTheUserByIdAndReturnBoolean()
     {
         $user = new LaravelUserStub();
 
@@ -491,7 +489,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_not_authenticate_the_user_by_id_and_return_false()
+    public function itShouldNotAuthenticateTheUserByIdAndReturnFalse()
     {
         $this->provider->shouldReceive('retrieveById')
             ->twice()
@@ -503,7 +501,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_create_a_token_from_a_user_object()
+    public function itShouldCreateATokenFromAUserObject()
     {
         $user = new LaravelUserStub();
 
@@ -531,7 +529,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_payload()
+    public function itShouldGetThePayload()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
         $this->jwt->shouldReceive('getToken')->once()->andReturn('foo.bar.baz');
@@ -540,7 +538,7 @@ class JWTGuardTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_be_macroable()
+    public function itShouldBeMacroable()
     {
         $this->guard->macro('foo', fn () => 'bar');
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -14,7 +14,6 @@ namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Mockery;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
@@ -59,7 +58,7 @@ class ManagerTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_encode_a_payload()
+    public function itShouldEncodeAPayload()
     {
         $claims = [
             new Subject(1),
@@ -85,7 +84,7 @@ class ManagerTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException|TokenBlacklistedException
      */
-    public function it_should_decode_a_token()
+    public function itShouldDecodeAToken()
     {
         $claims = [
             new Subject(1),
@@ -119,7 +118,7 @@ class ManagerTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_throw_exception_when_token_is_blacklisted()
+    public function itShouldThrowExceptionWhenTokenIsBlacklisted()
     {
         $this->expectException(TokenBlacklistedException::class);
         $this->expectExceptionMessage('The token has been blacklisted');
@@ -152,7 +151,7 @@ class ManagerTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_refresh_a_token()
+    public function itShouldRefreshAToken()
     {
         $claims = [
             new Subject(1),
@@ -188,7 +187,7 @@ class ManagerTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_invalidate_a_token()
+    public function itShouldInvalidateAToken()
     {
         $claims = [
             new Subject(1),
@@ -220,7 +219,7 @@ class ManagerTest extends AbstractTestCase
     /** @test
      * @throws InvalidClaimException
      */
-    public function it_should_force_invalidate_a_token_forever()
+    public function itShouldForceInvalidateATokenForever()
     {
         $claims = [
             new Subject(1),
@@ -250,7 +249,7 @@ class ManagerTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_enable_blacklist_is_set_to_false()
+    public function itShouldThrowAnExceptionWhenEnableBlacklistIsSetToFalse()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('You must have the blacklist enabled to invalidate a token.');
@@ -261,25 +260,25 @@ class ManagerTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_payload_factory()
+    public function itShouldGetThePayloadFactory()
     {
         $this->assertInstanceOf(Factory::class, $this->manager->getPayloadFactory());
     }
 
     /** @test */
-    public function it_should_get_the_jwt_provider()
+    public function itShouldGetTheJwtProvider()
     {
         $this->assertInstanceOf(JWT::class, $this->manager->getJWTProvider());
     }
 
     /** @test */
-    public function it_should_get_the_blacklist()
+    public function itShouldGetTheBlacklist()
     {
         $this->assertInstanceOf(Blacklist::class, $this->manager->getBlacklist());
     }
 
     /** @test */
-    public function test_if_show_blacklisted_exception_configuration_is_enabled()
+    public function testIfShowBlacklistedExceptionConfigurationIsEnabled()
     {
         $this->manager->setBlackListExceptionEnabled(true);
 
@@ -287,7 +286,7 @@ class ManagerTest extends AbstractTestCase
     }
 
     /** @test */
-    public function test_if_black_listed_exception_is_set_to_true()
+    public function testIfBlackListedExceptionIsSetToTrue()
     {
         $this->manager->setBlackListExceptionEnabled(true);
 
@@ -295,7 +294,7 @@ class ManagerTest extends AbstractTestCase
     }
 
     /** @test */
-    public function test_if_black_listed_exception_is_set_to_false()
+    public function testIfBlackListedExceptionIsSetToFalse()
     {
         $this->manager->setBlackListExceptionEnabled(false);
 

--- a/tests/Middleware/AuthenticateAndRenewTest.php
+++ b/tests/Middleware/AuthenticateAndRenewTest.php
@@ -36,7 +36,7 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
     }
 
     /** @test */
-    public function it_should_authenticate_a_user_and_return_a_new_token()
+    public function itShouldAuthenticateAUserAndReturnANewToken()
     {
         $parser = Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
@@ -55,7 +55,7 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
     }
 
     /** @test */
-    public function it_should_throw_an_unauthorized_exception_if_token_not_provided()
+    public function itShouldThrowAnUnauthorizedExceptionIfTokenNotProvided()
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -66,12 +66,11 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 
     /** @test */
-    public function it_should_throw_an_unauthorized_exception_if_token_invalid()
+    public function itShouldThrowAnUnauthorizedExceptionIfTokenInvalid()
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -84,7 +83,6 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 }

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -34,7 +34,7 @@ class AuthenticateTest extends AbstractMiddlewareTest
     }
 
     /** @test */
-    public function it_should_authenticate_a_user()
+    public function itShouldAuthenticateAUser()
     {
         $parser = Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
@@ -45,12 +45,11 @@ class AuthenticateTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 
     /** @test */
-    public function it_should_throw_an_unauthorized_exception_if_token_not_provided()
+    public function itShouldThrowAnUnauthorizedExceptionIfTokenNotProvided()
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -61,12 +60,11 @@ class AuthenticateTest extends AbstractMiddlewareTest
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 
     /** @test */
-    public function it_should_throw_an_unauthorized_exception_if_token_invalid()
+    public function itShouldThrowAnUnauthorizedExceptionIfTokenInvalid()
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -79,12 +77,11 @@ class AuthenticateTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 
     /** @test */
-    public function it_should_throw_an_unauthorized_exception_if_user_not_found()
+    public function itShouldThrowAnUnauthorizedExceptionIfUserNotFound()
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -97,7 +94,6 @@ class AuthenticateTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(false);
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 }

--- a/tests/Middleware/CheckTest.php
+++ b/tests/Middleware/CheckTest.php
@@ -33,7 +33,7 @@ class CheckTest extends AbstractMiddlewareTest
     }
 
     /** @test */
-    public function it_should_authenticate_a_user_if_a_token_is_present()
+    public function itShouldAuthenticateAUserIfATokenIsPresent()
     {
         $parser = Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
@@ -44,12 +44,11 @@ class CheckTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andReturn(new UserStub());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 
     /** @test */
-    public function it_should_unset_the_exception_if_a_token_is_present()
+    public function itShouldUnsetTheExceptionIfATokenIsPresent()
     {
         $parser = Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
@@ -60,12 +59,11 @@ class CheckTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->authenticate')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 
     /** @test */
-    public function it_should_do_nothing_if_a_token_is_not_present()
+    public function itShouldDoNothingIfATokenIsNotPresent()
     {
         $parser = Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
@@ -76,7 +74,6 @@ class CheckTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->authenticate')->never();
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 }

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -34,7 +34,7 @@ class RefreshTokenTest extends AbstractMiddlewareTest
     }
 
     /** @test */
-    public function it_should_refresh_a_token()
+    public function itShouldRefreshAToken()
     {
         $parser = Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
@@ -52,7 +52,7 @@ class RefreshTokenTest extends AbstractMiddlewareTest
     }
 
     /** @test */
-    public function it_should_throw_an_unauthorized_exception_if_token_not_provided()
+    public function itShouldThrowAnUnauthorizedExceptionIfTokenNotProvided()
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -63,12 +63,11 @@ class RefreshTokenTest extends AbstractMiddlewareTest
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 
     /** @test */
-    public function it_should_throw_an_unauthorized_exception_if_token_invalid()
+    public function itShouldThrowAnUnauthorizedExceptionIfTokenInvalid()
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -81,7 +80,6 @@ class RefreshTokenTest extends AbstractMiddlewareTest
         $this->auth->shouldReceive('parseToken->refresh')->once()->andThrow(new TokenInvalidException());
 
         $this->middleware->handle($this->request, function () {
-            //
         });
     }
 }

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -46,9 +46,8 @@ class PayloadTest extends AbstractTestCase
     }
 
     /**
-     * @param array $extraClaims
-     *
      * @return Payload
+     *
      * @throws InvalidClaimException
      */
     private function getTestPayload(array $extraClaims = [])
@@ -75,7 +74,7 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_trying_to_add_to_the_payload()
+    public function itShouldThrowAnExceptionWhenTryingToAddToThePayload()
     {
         $this->expectException(PayloadException::class);
         $this->expectExceptionMessage('The payload is immutable');
@@ -84,7 +83,7 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_trying_to_remove_a_key_from_the_payload()
+    public function itShouldThrowAnExceptionWhenTryingToRemoveAKeyFromThePayload()
     {
         $this->expectException(PayloadException::class);
         $this->expectExceptionMessage('The payload is immutable');
@@ -93,14 +92,14 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_cast_the_payload_to_a_string_as_json()
+    public function itShouldCastThePayloadToAStringAsJson()
     {
-        $this->assertSame((string)$this->payload, json_encode($this->payload->get(), JSON_UNESCAPED_SLASHES));
-        $this->assertJsonStringEqualsJsonString((string)$this->payload, json_encode($this->payload->get()));
+        $this->assertSame((string) $this->payload, json_encode($this->payload->get(), JSON_UNESCAPED_SLASHES));
+        $this->assertJsonStringEqualsJsonString((string) $this->payload, json_encode($this->payload->get()));
     }
 
     /** @test */
-    public function it_should_allow_array_access_on_the_payload()
+    public function itShouldAllowArrayAccessOnThePayload()
     {
         $this->assertTrue(isset($this->payload['iat']));
         $this->assertSame($this->payload['sub'], 1);
@@ -108,7 +107,7 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_properties_of_payload_via_get_method()
+    public function itShouldGetPropertiesOfPayloadViaGetMethod()
     {
         $this->assertIsArray($this->payload->get());
         $this->assertSame($this->payload->get('sub'), 1);
@@ -120,7 +119,7 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_multiple_properties_when_passing_an_array_to_the_get_method()
+    public function itShouldGetMultiplePropertiesWhenPassingAnArrayToTheGetMethod()
     {
         $values = $this->payload->get(['sub', 'jti']);
 
@@ -133,14 +132,14 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_determine_whether_the_payload_has_a_claim()
+    public function itShouldDetermineWhetherThePayloadHasAClaim()
     {
         $this->assertTrue($this->payload->has(new Subject(1)));
         $this->assertFalse($this->payload->has(new Audience(1)));
     }
 
     /** @test */
-    public function it_should_magically_get_a_property()
+    public function itShouldMagicallyGetAProperty()
     {
         $sub = $this->payload->getSubject();
         $jti = $this->payload->getJwtId();
@@ -152,7 +151,7 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_invoke_the_instance_as_a_callable()
+    public function itShouldInvokeTheInstanceAsACallable()
     {
         $payload = $this->payload;
 
@@ -168,7 +167,7 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_magically_getting_a_property_that_does_not_exist()
+    public function itShouldThrowAnExceptionWhenMagicallyGettingAPropertyThatDoesNotExist()
     {
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('The claim [Foo] does not exist on the payload');
@@ -177,7 +176,7 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_claims()
+    public function itShouldGetTheClaims()
     {
         $claims = $this->payload->getClaims();
 
@@ -189,29 +188,29 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_the_object_as_json()
+    public function itShouldGetTheObjectAsJson()
     {
         $this->assertJsonStringEqualsJsonString(json_encode($this->payload), $this->payload->toJson());
     }
 
     /** @test */
-    public function it_should_count_the_claims()
+    public function itShouldCountTheClaims()
     {
         $this->assertSame(6, $this->payload->count());
         $this->assertCount(6, $this->payload);
     }
 
     /** @test */
-    public function it_should_match_values()
+    public function itShouldMatchValues()
     {
         $values = $this->payload->toArray();
-        $values['sub'] = (string)$values['sub'];
+        $values['sub'] = (string) $values['sub'];
 
         $this->assertTrue($this->payload->matches($values));
     }
 
     /** @test */
-    public function it_should_match_strict_values()
+    public function itShouldMatchStrictValues()
     {
         $values = $this->payload->toArray();
 
@@ -220,13 +219,13 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_not_match_empty_values()
+    public function itShouldNotMatchEmptyValues()
     {
         $this->assertFalse($this->payload->matches([]));
     }
 
     /** @test */
-    public function it_should_not_match_values()
+    public function itShouldNotMatchValues()
     {
         $values = $this->payload->toArray();
         $values['sub'] = 'dummy_subject';
@@ -235,17 +234,17 @@ class PayloadTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_not_match_strict_values()
+    public function itShouldNotMatchStrictValues()
     {
         $values = $this->payload->toArray();
-        $values['sub'] = (string)$values['sub'];
+        $values['sub'] = (string) $values['sub'];
 
         $this->assertFalse($this->payload->matchesStrict($values));
         $this->assertFalse($this->payload->matches($values, true));
     }
 
     /** @test */
-    public function it_should_not_match_a_non_existing_claim()
+    public function itShouldNotMatchANonExistingClaim()
     {
         $values = ['foo' => 'bar'];
 

--- a/tests/Providers/Auth/IlluminateTest.php
+++ b/tests/Providers/Auth/IlluminateTest.php
@@ -39,30 +39,30 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_true_if_credentials_are_valid()
+    public function itShouldReturnTrueIfCredentialsAreValid()
     {
         $this->authManager->shouldReceive('once')->once()->with(['email' => 'foo@bar.com', 'password' => 'foobar'])->andReturn(true);
         $this->assertTrue($this->auth->byCredentials(['email' => 'foo@bar.com', 'password' => 'foobar']));
     }
 
     /** @test */
-    public function it_should_return_true_if_user_is_found()
+    public function itShouldReturnTrueIfUserIsFound()
     {
         $this->authManager->shouldReceive('onceUsingId')->once()->with(123)->andReturn(true);
         $this->assertTrue($this->auth->byId(123));
     }
 
     /** @test */
-    public function it_should_return_false_if_user_is_not_found()
+    public function itShouldReturnFalseIfUserIsNotFound()
     {
         $this->authManager->shouldReceive('onceUsingId')->once()->with(123)->andReturn(false);
         $this->assertFalse($this->auth->byId(123));
     }
 
     /** @test */
-    public function it_should_return_the_currently_authenticated_user()
+    public function itShouldReturnTheCurrentlyAuthenticatedUser()
     {
-        $this->authManager->shouldReceive('user')->once()->andReturn((object)['id' => 1]);
+        $this->authManager->shouldReceive('user')->once()->andReturn((object) ['id' => 1]);
         $this->assertSame($this->auth->user()->id, 1);
     }
 }

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -27,7 +27,6 @@ use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Lcobucci;
-use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Namshi;
 use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 
 class LcobucciTest extends AbstractTestCase
@@ -63,7 +62,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_when_passing_a_valid_payload_to_encode()
+    public function itShouldReturnTheTokenWhenPassingAValidPayloadToEncode()
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
@@ -86,7 +85,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_invalid_exception_when_the_payload_could_not_be_encoded()
+    public function itShouldThrowAnInvalidExceptionWhenThePayloadCouldNotBeEncoded()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('Could not create token:');
@@ -107,7 +106,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_payload_when_passing_a_valid_token_to_decode()
+    public function itShouldReturnThePayloadWhenPassingAValidTokenToDecode()
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
@@ -125,7 +124,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_a_token_invalid_exception_when_the_token_could_not_be_decoded_due_to_a_bad_signature()
+    public function itShouldThrowATokenInvalidExceptionWhenTheTokenCouldNotBeDecodedDueToABadSignature()
     {
         $token = Mockery::mock(Token::class);
         $dataSet = Mockery::mock(new DataSet(['pay', 'load'], 'payload'));
@@ -144,7 +143,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_a_token_invalid_exception_when_the_token_could_not_be_decoded()
+    public function itShouldThrowATokenInvalidExceptionWhenTheTokenCouldNotBeDecoded()
     {
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Could not decode token:');
@@ -157,7 +156,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_generate_a_token_when_using_an_rsa_algorithm()
+    public function itShouldGenerateATokenWhenUsingAnRsaAlgorithm()
     {
         $dummyPrivateKey = $this->getDummyPrivateKey();
         $dummyPublicKey = $this->getDummyPublicKey();
@@ -188,7 +187,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_a_exception_when_the_algorithm_passed_is_invalid()
+    public function itShouldThrowAExceptionWhenTheAlgorithmPassedIsInvalid()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('The given algorithm could not be found');
@@ -200,7 +199,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_public_key()
+    public function itShouldReturnThePublicKey()
     {
         $provider = $this->getProvider(
             'does_not_matter',
@@ -212,7 +211,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_keys()
+    public function itShouldReturnTheKeys()
     {
         $provider = $this->getProvider(
             'does_not_matter',
@@ -224,7 +223,7 @@ class LcobucciTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_correctly_instantiate_an_ecdsa_signer()
+    public function itShouldCorrectlyInstantiateAnEcdsaSigner()
     {
         $provider = new Lcobucci(
             'does_not_matter',
@@ -257,11 +256,11 @@ class LcobucciTest extends AbstractTestCase
 
     public function getDummyPrivateKey()
     {
-        return file_get_contents(__DIR__ . '/../Keys/id_rsa');
+        return file_get_contents(__DIR__.'/../Keys/id_rsa');
     }
 
     public function getDummyPublicKey()
     {
-        return file_get_contents(__DIR__ . '/../Keys/id_rsa.pub');
+        return file_get_contents(__DIR__.'/../Keys/id_rsa.pub');
     }
 }

--- a/tests/Providers/JWT/NamshiTest.php
+++ b/tests/Providers/JWT/NamshiTest.php
@@ -42,7 +42,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_when_passing_a_valid_payload_to_encode()
+    public function itShouldReturnTheTokenWhenPassingAValidPayloadToEncode()
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
@@ -61,7 +61,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_invalid_exception_when_the_payload_could_not_be_encoded()
+    public function itShouldThrowAnInvalidExceptionWhenThePayloadCouldNotBeEncoded()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('Could not create token:');
@@ -75,7 +75,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_payload_when_passing_a_valid_token_to_decode()
+    public function itShouldReturnThePayloadWhenPassingAValidTokenToDecode()
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
@@ -87,7 +87,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_a_token_invalid_exception_when_the_token_could_not_be_decoded_due_to_a_bad_signature()
+    public function itShouldThrowATokenInvalidExceptionWhenTheTokenCouldNotBeDecodedDueToABadSignature()
     {
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Token Signature could not be verified.');
@@ -100,7 +100,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_a_token_invalid_exception_when_the_token_could_not_be_decoded()
+    public function itShouldThrowATokenInvalidExceptionWhenTheTokenCouldNotBeDecoded()
     {
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Could not decode token:');
@@ -113,7 +113,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_generate_a_token_when_using_an_rsa_algorithm()
+    public function itShouldGenerateATokenWhenUsingAnRsaAlgorithm()
     {
         $provider = $this->getProvider(
             'does_not_matter',
@@ -134,16 +134,16 @@ class NamshiTest extends AbstractTestCase
 
     public function getDummyPrivateKey()
     {
-        return file_get_contents(__DIR__ . '/../Keys/id_rsa');
+        return file_get_contents(__DIR__.'/../Keys/id_rsa');
     }
 
     public function getDummyPublicKey()
     {
-        return file_get_contents(__DIR__ . '/../Keys/id_rsa.pub');
+        return file_get_contents(__DIR__.'/../Keys/id_rsa.pub');
     }
 
     /** @test */
-    public function it_should_generate_a_token_when_using_an_ecdsa_algorithm()
+    public function itShouldGenerateATokenWhenUsingAnEcdsaAlgorithm()
     {
         $provider = $this->getProvider(
             'does_not_matter',
@@ -163,7 +163,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_decode_a_token_when_using_an_rsa_algorithm()
+    public function itShouldDecodeATokenWhenUsingAnRsaAlgorithm()
     {
         $provider = $this->getProvider(
             'does_not_matter',
@@ -183,7 +183,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_a_exception_when_the_algorithm_passed_is_invalid()
+    public function itShouldThrowAExceptionWhenTheAlgorithmPassedIsInvalid()
     {
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('The given algorithm could not be found');
@@ -195,7 +195,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_public_key()
+    public function itShouldReturnThePublicKey()
     {
         $provider = $this->getProvider(
             'does_not_matter',
@@ -207,7 +207,7 @@ class NamshiTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_keys()
+    public function itShouldReturnTheKeys()
     {
         $provider = $this->getProvider(
             'does_not_matter',

--- a/tests/Providers/JWT/ProviderTest.php
+++ b/tests/Providers/JWT/ProviderTest.php
@@ -30,7 +30,7 @@ class ProviderTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_set_the_algo()
+    public function itShouldSetTheAlgo()
     {
         $this->provider->setAlgo('HS512');
 
@@ -38,7 +38,7 @@ class ProviderTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_set_the_secret()
+    public function itShouldSetTheSecret()
     {
         $this->provider->setSecret('foo');
 

--- a/tests/Providers/Storage/IlluminateTest.php
+++ b/tests/Providers/Storage/IlluminateTest.php
@@ -40,7 +40,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_add_the_item_to_storage()
+    public function itShouldAddTheItemToStorage()
     {
         $this->cache->shouldReceive('put')->with('foo', 'bar', 10)->once();
 
@@ -48,7 +48,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_add_the_item_to_storage_forever()
+    public function itShouldAddTheItemToStorageForever()
     {
         $this->cache->shouldReceive('forever')->with('foo', 'bar')->once();
 
@@ -56,7 +56,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_an_item_from_storage()
+    public function itShouldGetAnItemFromStorage()
     {
         $this->cache->shouldReceive('get')->with('foo')->once()->andReturn(['foo' => 'bar']);
 
@@ -64,7 +64,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_remove_the_item_from_storage()
+    public function itShouldRemoveTheItemFromStorage()
     {
         $this->cache->shouldReceive('forget')->with('foo')->once()->andReturn(true);
 
@@ -72,7 +72,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_remove_all_items_from_storage()
+    public function itShouldRemoveAllItemsFromStorage()
     {
         $this->cache->shouldReceive('flush')->withNoArgs()->once();
 
@@ -82,7 +82,7 @@ class IlluminateTest extends AbstractTestCase
     // Duplicate tests for tagged storage --------------------
 
     /** @test */
-    public function it_should_add_the_item_to_tagged_storage()
+    public function itShouldAddTheItemToTaggedStorage()
     {
         $this->emulateTags();
         $this->cache->shouldReceive('put')->with('foo', 'bar', 10)->once();
@@ -104,7 +104,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_add_the_item_to_tagged_storage_forever()
+    public function itShouldAddTheItemToTaggedStorageForever()
     {
         $this->emulateTags();
         $this->cache->shouldReceive('forever')->with('foo', 'bar')->once();
@@ -113,7 +113,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_get_an_item_from_tagged_storage()
+    public function itShouldGetAnItemFromTaggedStorage()
     {
         $this->emulateTags();
         $this->cache->shouldReceive('get')->with('foo')->once()->andReturn(['foo' => 'bar']);
@@ -122,7 +122,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_remove_the_item_from_tagged_storage()
+    public function itShouldRemoveTheItemFromTaggedStorage()
     {
         $this->emulateTags();
         $this->cache->shouldReceive('forget')->with('foo')->once()->andReturn(true);
@@ -131,7 +131,7 @@ class IlluminateTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_remove_all_tagged_items_from_storage()
+    public function itShouldRemoveAllTaggedItemsFromStorage()
     {
         $this->emulateTags();
         $this->cache->shouldReceive('flush')->withNoArgs()->once();

--- a/tests/Stubs/LaravelUserStub.php
+++ b/tests/Stubs/LaravelUserStub.php
@@ -19,31 +19,25 @@ class LaravelUserStub extends UserStub implements Authenticatable, JWTSubject
 {
     public function getAuthIdentifierName()
     {
-        //
     }
 
     public function getAuthIdentifier()
     {
-        //
     }
 
     public function getAuthPassword()
     {
-        //
     }
 
     public function getRememberToken()
     {
-        //
     }
 
     public function setRememberToken($value)
     {
-        //
     }
 
     public function getRememberTokenName()
     {
-        //
     }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -29,13 +29,13 @@ class TokenTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_the_token_when_casting_to_a_string()
+    public function itShouldReturnTheTokenWhenCastingToAString()
     {
-        $this->assertEquals((string)$this->token, $this->token);
+        $this->assertEquals((string) $this->token, $this->token);
     }
 
     /** @test */
-    public function it_should_return_the_token_when_calling_get_method()
+    public function itShouldReturnTheTokenWhenCallingGetMethod()
     {
         $this->assertIsString($this->token->get());
     }

--- a/tests/Validators/PayloadValidatorTest.php
+++ b/tests/Validators/PayloadValidatorTest.php
@@ -38,9 +38,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_return_true_when_providing_a_valid_payload()
+    public function itShouldReturnTrueWhenProvidingAValidPayload()
     {
         $claims = [
             new Subject(1),
@@ -58,9 +59,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_throw_an_exception_when_providing_an_expired_payload()
+    public function itShouldThrowAnExceptionWhenProvidingAnExpiredPayload()
     {
         $this->expectException(TokenExpiredException::class);
         $this->expectExceptionMessage('Token has expired');
@@ -81,9 +83,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_throw_an_exception_when_providing_an_invalid_nbf_claim()
+    public function itShouldThrowAnExceptionWhenProvidingAnInvalidNbfClaim()
     {
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Not Before (nbf) timestamp cannot be in the future');
@@ -103,7 +106,7 @@ class PayloadValidatorTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_providing_an_invalid_iat_claim()
+    public function itShouldThrowAnExceptionWhenProvidingAnInvalidIatClaim()
     {
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('Invalid value provided for claim [iat]');
@@ -124,9 +127,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_throw_an_exception_when_providing_an_invalid_payload()
+    public function itShouldThrowAnExceptionWhenProvidingAnInvalidPayload()
     {
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('JWT payload does not contain the required claims');
@@ -142,7 +146,7 @@ class PayloadValidatorTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_throw_an_exception_when_providing_an_invalid_expiry()
+    public function itShouldThrowAnExceptionWhenProvidingAnInvalidExpiry()
     {
         $this->expectException(InvalidClaimException::class);
         $this->expectExceptionMessage('Invalid value provided for claim [exp]');
@@ -163,9 +167,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_set_the_required_claims()
+    public function itShouldSetTheRequiredClaims()
     {
         $claims = [
             new Subject(1),
@@ -179,9 +184,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_check_the_token_in_the_refresh_context()
+    public function itShouldCheckTheTokenInTheRefreshContext()
     {
         $claims = [
             new Subject(1),
@@ -201,9 +207,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_return_true_if_the_refresh_ttl_is_null()
+    public function itShouldReturnTrueIfTheRefreshTtlIsNull()
     {
         $claims = [
             new Subject(1),
@@ -223,9 +230,10 @@ class PayloadValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @throws InvalidClaimException
      */
-    public function it_should_throw_an_exception_if_the_token_cannot_be_refreshed()
+    public function itShouldThrowAnExceptionIfTheTokenCannotBeRefreshed()
     {
         $this->expectException(TokenExpiredException::class);
         $this->expectExceptionMessage('Token has expired and can no longer be refreshed');

--- a/tests/Validators/TokenValidatorTest.php
+++ b/tests/Validators/TokenValidatorTest.php
@@ -31,7 +31,7 @@ class TokenValidatorTest extends AbstractTestCase
     }
 
     /** @test */
-    public function it_should_return_true_when_providing_a_well_formed_token()
+    public function itShouldReturnTrueWhenProvidingAWellFormedToken()
     {
         $this->assertTrue($this->validator->isValid('one.two.three'));
     }
@@ -42,7 +42,7 @@ class TokenValidatorTest extends AbstractTestCase
      *
      * @param string $token
      */
-    public function it_should_return_false_when_providing_a_malformed_token($token)
+    public function itShouldReturnFalseWhenProvidingAMalformedToken($token)
     {
         $this->assertFalse($this->validator->isValid($token));
     }
@@ -51,7 +51,7 @@ class TokenValidatorTest extends AbstractTestCase
      * @test
      * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderMalformedTokens
      */
-    public function it_should_throw_an_exception_when_providing_a_malformed_token($token)
+    public function itShouldThrowAnExceptionWhenProvidingAMalformedToken($token)
     {
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Malformed token');
@@ -63,7 +63,7 @@ class TokenValidatorTest extends AbstractTestCase
      * @test
      * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
      */
-    public function it_should_return_false_when_providing_a_token_with_wrong_segments_number($token)
+    public function itShouldReturnFalseWhenProvidingATokenWithWrongSegmentsNumber($token)
     {
         $this->assertFalse($this->validator->isValid($token));
     }
@@ -72,7 +72,7 @@ class TokenValidatorTest extends AbstractTestCase
      * @test
      * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
      */
-    public function it_should_throw_an_exception_when_providing_a_malformed_token_with_wrong_segments_number($token)
+    public function itShouldThrowAnExceptionWhenProvidingAMalformedTokenWithWrongSegmentsNumber($token)
     {
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Wrong number of segments');


### PR DESCRIPTION
## Summary
The first rule set I chose, `@PSR12`, is also quite un-opinionated in many aspects.

I checks the diffs of the rule sets of `@Symfony`, `@PhpCsFixer` and ultimately concluded that the former, for a rule set, gives the best net outcome:
- it's not risky
- it removed redundant phpdoc

I understand this is a Laravel project and it would make sense to embrace their coding standard, but they've no "official" one for php-cs-fixer as they're relying on the styleci service (which I believe under the hood uses php-cs-fixer or related tools anyway).

There's also https://github.com/matt-allan/laravel-code-style and I was using it in some projects in the past, but I was not happy with the result (still lacked some "opinions" AFAIR). I also maintain my own https://github.com/mfn/php-cs-fixer-config but this is risky and definitely can't be used with this projects, besides no one heard of it lest would agree to use it 😬

The PR already contains a diff of the changes as a second commit, as auto-generated by the Github Action.