### PR TITLE
github: add dedicated templates for bug reports and features, also link to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -1,7 +1,13 @@
+---
+name: "🐛 Bug Report"
+about: 'Report a general bug.'
+labels: bug
+
+---
 ### Subject of the issue
 Describe your issue here.
 
-### Your environment
+### Your environment:
 | Q                 | A
 | ----------------- | ---
 | Bug?              | no / yes

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -1,0 +1,12 @@
+---
+name: "✨ Feature request"
+about: 'Suggest a new feature or other improvements.'
+labels: enhancement
+
+---
+
+### Summary
+
+<!--
+Describe in detail what you propose, show (preferable) code examples and also signal if you're willing to work on it!
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 🙋🏼‍♂️ Support Questions & Other
+      url: https://github.com/PHP-Open-Source-Saver/jwt-auth/discussions/new
+      about: 'I need assistance or clarification on usage of this library.'


### PR DESCRIPTION
Hi 👋🏼 

I'm proposing to improve the issue template a bit to:
- provide a clear bug report (incl. label)
- one for enhancements
- also for general support refer to the discussions

The existing issue template was basically just moved and adapted.

Not 100% sure, but I think the `SECURITY.md` content will also be referenced from this; it will look similar to https://github.com/laravel/framework/issues/new/choose I believe.