### PR TITLE
github: unify the security contact at the github supported policy document

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Work in progress.
 
 ## Security
 
-If you discover any security related issues, please email messhias@gmail.com or eric.schricker@adiutabyte.de instead of using the issue tracker.
+If you want to disclose a security related issue, please follow our [security policy](https://github.com/PHP-Open-Source-Saver/jwt-auth/security/policy)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,6 @@
 # Security Policy
 
-## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
-
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
-
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+If you discover any security related issues, please email messhias@gmail.com or
+eric.schricker@adiutabyte.de instead of using the issue tracker.


### PR DESCRIPTION
## Summary
The reason for moving the email addresses over is that the security policy
(`SECURITY.md`) is auto-link from a few places by github itself and should
therefore contain the primary contacts.

Further I removed the "supported versions" table which seems to be a
copy-pasta from a default until we define a clear guide here.