### PR TITLE
composer.json: allow installing with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4|^8.0|^8.1",
         "ext-json": "*",
         "illuminate/auth": "^6|^7|^8",
         "illuminate/contracts": "^6|^7|^8",


### PR DESCRIPTION
So, uh, [we enabled testing for 8.1](https://github.com/PHP-Open-Source-Saver/jwt-auth/pull/58) but we actually don't allow this package to be installed on 8.1? 😅

Not sure if I missed something here 😬 But if not, allow installing for 8.1!