### PR TITLE
Add phpstan to the project, start small at level 1 with baseline

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,46 @@
+name: PHPStan
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Run Monday morning at 3 o'clock
+    #       ┌───────────── minute (0 - 59)
+    #       │ ┌───────────── hour (0 - 23)
+    #       │ │ ┌───────────── day of the month (1 - 31)
+    #       │ │ │ ┌───────────── month (1 - 12)
+    #       │ │ │ │ ┌───────────── day of the week (0 - 6)
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    - cron: 0 3 * * 1
+  workflow_dispatch:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    env:
+      COMPOSER_NO_INTERACTION: 1
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - run: composer update --prefer-dist --no-progress
+
+      - run: composer phpstan -- --no-progress

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,6 +3,10 @@ name: PHPStan
 on:
   pull_request:
   push:
+    branches:
+      - main
+      - develop
+      - release/**
   schedule:
     # Run Monday morning at 3 o'clock
     #       ┌───────────── minute (0 - 59)

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "illuminate/console": "^6|^7|^8",
         "illuminate/routing": "^6|^7|^8",
         "mockery/mockery": "^1.4",
+        "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^8.5|^9.4",
         "rector/rector": "^0.12.4",
         "vlucas/phpdotenv": "^5.2.0",

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,8 @@
     "scripts": {
         "php-cs-fixer": "php-cs-fixer fix --diff",
         "test": "phpunit --colors=always",
-        "test:ci": "composer test -- --verbose --coverage-text --coverage-clover=coverage.xml"
+        "test:ci": "composer test -- --verbose --coverage-text --coverage-clover=coverage.xml",
+        "phpstan": "phpstan analyse --memory-limit=256M",
+        "phpstan-baseline": "phpstan analyse --generate-baseline --memory-limit=256M"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,62 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Claims/Collection.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\Expiration\\:\\:validatePayload\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: src/Claims/Expiration.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\IssuedAt\\:\\:validatePayload\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: src/Claims/IssuedAt.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\IssuedAt\\:\\:validateRefresh\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: src/Claims/IssuedAt.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\NotBefore\\:\\:validatePayload\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: src/Claims/NotBefore.php
+
+		-
+			message: "#^Result of method PHPOpenSourceSaver\\\\JWTAuth\\\\Console\\\\JWTGenerateSecretCommand\\:\\:displayKey\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: src/Console/JWTGenerateSecretCommand.php
+
+		-
+			message: "#^Function config not found\\.$#"
+			count: 1
+			path: src/Providers/AbstractServiceProvider.php
+
+		-
+			message: "#^Function config_path not found\\.$#"
+			count: 1
+			path: src/Providers/LaravelServiceProvider.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Test\\\\Stubs\\\\LaravelUserStub\\:\\:getAuthIdentifierName\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Stubs/LaravelUserStub.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Test\\\\Stubs\\\\LaravelUserStub\\:\\:getAuthPassword\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Stubs/LaravelUserStub.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Test\\\\Stubs\\\\LaravelUserStub\\:\\:getRememberToken\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Stubs/LaravelUserStub.php
+
+		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Test\\\\Stubs\\\\LaravelUserStub\\:\\:getRememberTokenName\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Stubs/LaravelUserStub.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+includes:
+    - ./phpstan-baseline.neon
+parameters:
+    level: 1
+    paths:
+        - src/
+        - tests/

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -202,6 +202,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return Arr::has($this->toArray(), $key);
@@ -227,6 +228,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @throws PayloadException
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         throw new PayloadException('The payload is immutable');
@@ -241,6 +243,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      * @throws PayloadException
      *
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         throw new PayloadException('The payload is immutable');
@@ -251,6 +254,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->toArray());


### PR DESCRIPTION
## Summary
Here's my proposal to add https://phpstan.org/user-guide/getting-started into this project 👋🏼 

I've been using if for years in various projects to great success. It can be daunting at first for existing projects, but the sooner it's added, the better.

This PR includes:
- making phpstan a dev dependency, add a basic config+baseline
  (it already was a transient one, this now makes it explicit)
- add composer script entries for it
- add a github action to run phpstan
  (which uses above composer script entries)
- Add `#[\ReturnTypeWillChange]` annotation for PHP 8.1 compatibility
  This one was already exposed by phpstan 😅 and since annotations are comments and thus backwards compatible, this is the only "source level" change here:
  ```
   ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
    Line   src/Payload.php                                                                                                                                                         
   ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
    205    Return type mixed of method PHPOpenSourceSaver\JWTAuth\Payload::offsetExists() is not covariant with tentative return type bool of method ArrayAccess::offsetExists().  
           💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.                                                                  
    230    Return type mixed of method PHPOpenSourceSaver\JWTAuth\Payload::offsetSet() is not covariant with tentative return type void of method ArrayAccess::offsetSet().        
           💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.                                                                  
    244    Return type mixed of method PHPOpenSourceSaver\JWTAuth\Payload::offsetUnset() is not covariant with tentative return type void of method ArrayAccess::offsetUnset().    
           💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.                                                                  
    254    Return type mixed of method PHPOpenSourceSaver\JWTAuth\Payload::count() is not covariant with tentative return type int of method Countable::count().                   
           💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.                                                                  
   ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  ```

### Notes
- I opted to run phpstan with PHP 8.1. **This is important as the version you use to run phpstan is relevant and makes a difference in things being reported**. I understand PHP 8.1 just left the door, but didn't see a reason to go lower.
  
  Personally, I do use OSX / homebrew and 8.1 is already available here, so _for me_ local testing is possible already.
- This PR is "as unobtrusive as possible" to get the foot in the door for phpstan. That's why I chose a) the lowest level and b) added it fully to the baseline without any fixes yet.
  I believe any fixes further on need to go into 2.x for the compatibility to transition from the forked package

### Links
- See also https://github.com/PHP-Open-Source-Saver/jwt-auth/discussions/76#discussioncomment-1712879