### PR TITLE
Revert "composer.json: allow installing with PHP 8.1"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0|^8.1",
+        "php": "^7.4|^8.0",
         "ext-json": "*",
         "illuminate/auth": "^6|^7|^8",
         "illuminate/contracts": "^6|^7|^8",


### PR DESCRIPTION
## Summary

This reverts commit f2d5978d8a638ca8fada56255fd067f54fde3753 from PR https://github.com/PHP-Open-Source-Saver/jwt-auth/pull/77

^8.0 does include all 8.x version, it was a "I haven't had enough coffee error" on my part.