### PR TITLE
Set jsonSerialize() return type to match interface, fixes #81

### DIFF
--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -146,9 +146,9 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -146,9 +146,10 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return mixed
+     * @return array
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }


### PR DESCRIPTION
JsonSerializable::jsonSerialize() mandates a mixed type. While we use array, it should be fine to specify this as mixed in order to comply with the interface contract.

Close #87 