### PR TITLE
Updating guides for migrating from tymondesigns/jwt-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 
 This uses different namespace, then `tymondesigns/jwt-auth`, but overall, provides the same API, that makes migration to this repository pretty easy:
 
-1) Run `composer require php-open-source-saver/jwt-auth`
+1) Run `composer remove tymon/jwt-auth`
+   > **Info** An error will appear because the package is still in use, ignore it.
 2) Replace all the occurrences of `Tymon\JWTAuth` with `PHPOpenSourceSaver\JWTAuth`.
    > **Tip**: You can use *Find and Replace* feature of your IDE. Try it with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd>
-3) Run `composer remove tymon/jwt-auth`
+3) Run `composer require php-open-source-saver/jwt-auth`
 
 ### Notes
 


### PR DESCRIPTION
The current migrating guide will fail, because we try to install this package and there's still `lcobucci/jwt` from the old version locked by `tymon/jwt-auth`. We will get something like:

```
Problem 1
    - Root composer.json requires php-open-source-saver/jwt-auth ^1.2 -> satisfiable by php-open-source-saver/jwt-auth[1.2.0].
    - php-open-source-saver/jwt-auth 1.2.0 requires lcobucci/jwt ^4.0 -> found lcobucci/jwt[4.0.0-alpha1, ..., 4.2.x-dev] but the package is fixed to 3.3.3 (Not match. Make sure you list it as an argument for the update command).
```

To avoid this, either Renaming `Tymon\JWTAuth` to `PHPOpenSourceSaver\JWTAuth` namespace or Removing `tymon/jwt-auth` first will success.