### PR TITLE
Allow null secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can find and compare releases at the GitHub release page.
 ### Added
 
 ### Fixed
+- Fixes #101 - Secret is not nullable but should be according to the library config boilerplate
 
 ## [1.3.0] - 2022-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ You can find and compare releases at the GitHub release page.
 - Typo in tests by @eschricker in #23
 
 [Unreleased]: https://github.com/PHP-Open-Source-Saver/jwt-auth/compare/1.3.0...HEAD
-[1.3.0]: https://github.com/PHP-Open-Source-Saver/jwt-auth/compare/1.3.0...1.2.0
+[1.3.0]: https://github.com/PHP-Open-Source-Saver/jwt-auth/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/PHP-Open-Source-Saver/jwt-auth/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/PHP-Open-Source-Saver/jwt-auth/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/PHP-Open-Source-Saver/jwt-auth/compare/1.0.2...1.1.0

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -20,7 +20,7 @@ abstract class Provider
     /**
      * The secret.
      */
-    protected string $secret;
+    protected ?string $secret;
 
     /**
      * The array of keys.

--- a/tests/Providers/JWT/ProviderEmptySecretTest.php
+++ b/tests/Providers/JWT/ProviderEmptySecretTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) 2014-2021 Sean Tymon <tymon148@gmail.com>
+ * (c) 2021 PHP Open Source Saver
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\JWT;
+
+use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
+use PHPOpenSourceSaver\JWTAuth\Test\Stubs\JWTProviderStub;
+
+class ProviderEmptySecretTest extends AbstractTestCase
+{
+    /**
+     * @var JWTProviderStub
+     */
+    protected $provider;
+
+
+    /** @test */
+    public function noExceptionForNULL()
+    {
+        $this->provider = new JWTProviderStub(NULL, 'RS256', []);
+
+        $this->provider->setSecret(NULL);
+        $this->assertSame(NULL, $this->provider->getSecret());
+    }
+}


### PR DESCRIPTION
not all hashing algos require the use of a secret.

This PR allows for passing null values for the secret - in my case a missing .env file entry for the secret caused the error, but even not including the secret in the config file would cause the error to be thrown.

<!-- Provide a general summary of your changes in the Title above -->

## Description

Fixes #101 

## Checklist:

- [ √ ] I've added tests for my changes or tests are not applicable
- [ √ ] documentations changes are not required
- Changes are not notable - no changes made to  [`CHANGELOG.md`](/CHANGELOG.md)
