### PR TITLE
Fix path to header now that the develop branch was removed

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 JSON Web Token Authentication for Laravel & Lumen
 
-![jwt-auth-banner](https://raw.githubusercontent.com/PHP-Open-Source-Saver/jwt-auth/develop/.github/banner.png)
+![jwt-auth-banner](https://raw.githubusercontent.com/PHP-Open-Source-Saver/jwt-auth/main/.github/banner.png)


### PR DESCRIPTION
## Description
Currently on https://laravel-jwt-auth.readthedocs.io/en/latest/ it renders like this, because the path is wrong:
![image](https://user-images.githubusercontent.com/87493/149573998-951d6ffa-bb81-4105-9968-4ac0fd075149.png)

With `main` it will work again.

## Checklist:

- [ ] ~I've added tests for my changes or tests are not applicable~
- [ ] ~I've changed documentations or changes are not required~
- [ ] ~I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)~
