### PR TITLE
Hotfix/fix php 8.1 warnings

### DIFF
--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -146,7 +146,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -65,7 +65,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return bool
      */
-    public function matches(array $values, $strict = false)
+    public function matches(array $values, bool $strict = false): bool
     {
         if (empty($values)) {
             return false;
@@ -89,7 +89,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return bool
      */
-    public function matchesStrict(array $values)
+    public function matchesStrict(array $values): bool
     {
         return $this->matches($values, true);
     }
@@ -167,7 +167,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -197,36 +197,36 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Determine if an item exists at an offset.
      *
-     * @param mixed $key
+     * @param mixed $offset
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($offset): bool
     {
-        return Arr::has($this->toArray(), $key);
+        return Arr::has($this->toArray(), $offset);
     }
 
     /**
      * Get an item at a given offset.
      *
-     * @param mixed $key
+     * @param mixed $offset
      *
      * @return mixed
      */
-    public function offsetGet($key)
+    public function offsetGet($offset): mixed
     {
-        return Arr::get($this->toArray(), $key);
+        return Arr::get($this->toArray(), $offset);
     }
 
     /**
      * Don't allow changing the payload as it should be immutable.
      *
-     * @param mixed $key
+     * @param mixed $offset
      * @param mixed $value
      *
      * @throws PayloadException
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new PayloadException('The payload is immutable');
     }
@@ -234,13 +234,13 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Don't allow changing the payload as it should be immutable.
      *
-     * @param string $key
+     * @param string $offset
      *
      * @return void
      * @throws PayloadException
      *
      */
-    public function offsetUnset($key)
+    public function offsetUnset($offset): void
     {
         throw new PayloadException('The payload is immutable');
     }
@@ -250,7 +250,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->toArray());
     }


### PR DESCRIPTION
# Fix PHP 8.1 warngins as per #104 

## Description

Fixing PHP 8.1 warnings as peer #104 

Closes #104 

## Checklist:

- [ ] I've added tests for my changes or tests are not applicable
- [ ] I've changed documentation or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
