### PR TITLE
Add more ReturnTypeWillChange for PHP 8.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can find and compare releases at the GitHub release page.
 - Add Laravel 9 Support
 
 ### Fixed
+- Add more ReturnTypeWillChange for PHP 8.1 compatibility
 
 ## [1.4.0] - 2022-01-18
 

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -161,6 +161,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();
@@ -208,6 +209,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return Arr::get($this->toArray(), $key);


### PR DESCRIPTION
## Description

The return will have to be changed for > 8.1 and we're marking
the methods for now to keep the deprecation warnings away.

Fixes #104 and replaces #105

## Checklist:

- [ ] ~I've added tests for my changes or tests are not applicable~
- [ ] ~I've changed documentations or changes are not required~
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
