### PR TITLE
Added exception if secret key or private and public key is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 You can find and compare releases at the GitHub release page.
 
+## [Unreleased]
+
+### Added
+- Added exception if secret key or private/public key are missing
+
+### Fixed
+
 ## [1.4.1] - 2022-01-24
 
 ### Fixed

--- a/src/Exceptions/SecretMissingException.php
+++ b/src/Exceptions/SecretMissingException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of jwt-auth.
+ *
+ * (c) 2014-2021 Sean Tymon <tymon148@gmail.com>
+ * (c) 2021 PHP Open Source Saver
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
+
+class SecretMissingException extends JWTException
+{
+}

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -14,6 +14,7 @@ namespace PHPOpenSourceSaver\JWTAuth\Providers\JWT;
 
 use Illuminate\Support\Arr;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\SecretMissingException;
 
 abstract class Provider
 {
@@ -42,6 +43,10 @@ abstract class Provider
      */
     public function __construct($secret, $algo, array $keys)
     {
+        if(is_null($secret) && (is_null($keys['public']) || is_null($keys['private']))) {
+            throw new SecretMissingException();
+        }
+
         $this->secret = $secret;
         $this->algo = $algo;
         $this->keys = $keys;

--- a/tests/Providers/JWT/ProviderEmptySecretTest.php
+++ b/tests/Providers/JWT/ProviderEmptySecretTest.php
@@ -12,6 +12,7 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\JWT;
 
+use PHPOpenSourceSaver\JWTAuth\Exceptions\SecretMissingException;
 use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
 use PHPOpenSourceSaver\JWTAuth\Test\Stubs\JWTProviderStub;
 
@@ -23,11 +24,37 @@ class ProviderEmptySecretTest extends AbstractTestCase
     protected $provider;
 
     /** @test */
-    public function noExceptionForNULL()
+    public function asymmetricNoSecret()
     {
-        $this->provider = new JWTProviderStub(null, 'RS256', []);
+        $this->provider = new JWTProviderStub(null, 'RS256', ['public' => '123', 'private' => '456']);
 
-        $this->provider->setSecret(null);
+        $this->assertSame(null, $this->provider->getSecret());
+    }
+
+    /** @test */
+    public function asymmetricPublicMissing()
+    {
+        $this->expectException(SecretMissingException::class);
+        $this->provider = new JWTProviderStub(null, 'RS256', ['public' => null, 'private' => '456']);
+
+        $this->assertSame(null, $this->provider->getSecret());
+    }
+
+    /** @test */
+    public function asymmetricPrivateMissing()
+    {
+        $this->expectException(SecretMissingException::class);
+        $this->provider = new JWTProviderStub(null, 'RS256', ['public' => '123', 'private' => null]);
+
+        $this->assertSame(null, $this->provider->getSecret());
+    }
+
+    /** @test */
+    public function symmetricKeyMissing()
+    {
+        $this->expectException(SecretMissingException::class);
+        $this->provider = new JWTProviderStub(null, 'RS256', ['public' => null, 'private' => null]);
+
         $this->assertSame(null, $this->provider->getSecret());
     }
 }


### PR DESCRIPTION
If the secret key (symmetric algo) or private and public key (asymmetric algo) are missing, you will get a type mismatch error from Lcobucci (see https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/116). 

## Description

An own exception has been added which will be thrown, when the either the secret key or private/public key are missing. In that case you will get a better error message. 

Fixes #116

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
