### PR TITLE
Added command for generating certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 You can find and compare releases at the GitHub release page.
 
+## [Unreleased]
+
+### Added
+- Add command for generating certs
+
 ## [1.4.1] - 2022-01-24
 
 ### Fixed

--- a/docs/laravel-installation.md
+++ b/docs/laravel-installation.md
@@ -47,3 +47,39 @@ This will update your `.env` file with something like `JWT_SECRET=foobar`
 
 It is the key that will be used to sign your tokens. How that happens exactly will depend
 on the algorithm that you choose to use.
+
+### Generate certificate
+
+For generating certificates the command 
+
+```bash
+php artisan jwt:generate-certs
+```
+
+can be used. The `.env` file will be updated, to use the newly created certificates. 
+
+The command accepts for following paramters
+
+| name | description |
+|---|---|
+| force | override existing certificates |
+| algo | Either rsa or ec |
+| bits | Key length for rsa |
+| curve | Curve to be used for ec |
+| sha | Hashing algorithm |
+| passphrase | Passphrase for the cert |
+| dir | Folder to place the certificates |
+
+#### Examples 
+
+Generating a 4096 bit rsa certificate with sha 512
+
+```bash
+php artisan jwt:generate-certs --force --algo=rsa --bits=4096 --sha=512
+```
+
+Generating a ec certificate with prime256v1-curve and sha 512
+
+```bash
+php artisan jwt:generate-certs --force --algo=ec --curve=prime256v1 --sha=512
+```

--- a/docs/lumen-installation.md
+++ b/docs/lumen-installation.md
@@ -54,3 +54,39 @@ This will update your `.env` file with something like `JWT_SECRET=foobar`
 
 It is the key that will be used to sign your tokens. How that happens exactly will depend
 on the algorithm that you choose to use.
+
+### Generate certificate
+
+For generating certificates the command 
+
+```bash
+php artisan jwt:generate-certs
+```
+
+can be used. The `.env` file will be updated, to use the newly created certificates. 
+
+The command accepts for following paramters
+
+| name | description |
+|---|---|
+| force | override existing certificates |
+| algo | Either rsa or ec |
+| bits | Key length for rsa |
+| curve | Curve to be used for ec |
+| sha | Hashing algorithm |
+| passphrase | Passphrase for the cert |
+| dir | Folder to place the certificates |
+
+#### Examples 
+
+Generating a 4096 bit rsa certificate with sha 512
+
+```bash
+php artisan jwt:generate-certs --force --algo=rsa --bits=4096 --sha=512
+```
+
+Generating a ec certificate with prime256v1-curve and sha 512
+
+```bash
+php artisan jwt:generate-certs --force --algo=ec --curve=prime256v1 --sha=512
+```

--- a/src/Console/EnvHelperTrait.php
+++ b/src/Console/EnvHelperTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PHPOpenSourceSaver\JWTAuth\Console;
+
+use Closure;
+use Illuminate\Support\Str;
+
+trait EnvHelperTrait
+{
+    /**
+     * Checks if the env file exists
+     * 
+     * @return bool
+     */
+    function envFileExists(): bool
+    {
+        return file_exists($this->envPath());
+    }
+
+    /**
+     * Update an env-file entry
+     * 
+     * @param string $key
+     * @param string|int $value
+     * @param Closure|null $confirmOnExisting
+     * @return bool
+     */
+    function updateEnvEntry(string $key, $value, Closure $confirmOnExisting = null): bool
+    {
+        static $filepath = null;
+        
+        if(is_null($filepath)) {
+            $filepath = $this->envPath();
+        }
+
+        if (false === Str::contains(file_get_contents($filepath), $key)) {
+            // create new entry
+            file_put_contents(
+                $filepath,
+                PHP_EOL . "{$key}={$value}" . PHP_EOL,
+                FILE_APPEND
+            );
+
+            return true;
+        } else {
+            if(is_null($confirmOnExisting) || $confirmOnExisting()) {
+                // update existing entry
+                file_put_contents(
+                    $filepath,
+                    str_replace(
+                        "/{$key}=.*/",
+                        "{$key}={$value}",
+                        file_get_contents($filepath)
+                    )
+                );
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the .env file path.
+     *
+     * @return string
+     */
+    protected function envPath(): string
+    {
+        if (method_exists($this->laravel, 'environmentFilePath')) {
+            return $this->laravel->environmentFilePath();
+        }
+
+        // check if laravel version Less than 5.4.17
+        if (version_compare($this->laravel->version(), '5.4.17', '<')) {
+            return $this->laravel->basePath() . DIRECTORY_SEPARATOR . '.env';
+        }
+
+        return $this->laravel->basePath('.env');
+    }
+}

--- a/src/Console/JWTGenerateCertCommand.php
+++ b/src/Console/JWTGenerateCertCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace PHPOpenSourceSaver\JWTAuth\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class JWTGenerateCertCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'jwt:generate-certs {--force : Override certificates if existing} {--algo : Algorithm} {--bits : Key length} {--sha : SHA-variant} {--dir : Directory} {--passphrase : Passphrase}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generates a new cert pair';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $force = boolval($this->option('force')) ?? false;
+        $directory = $this->option('dir') ?? 'storage/certs';
+        $algo = $this->option('algo') ?? 'rsa';
+        $bits = intval($this->option('bits')) ?? 4096;
+        $shaVariant = intval($this->option('sha')) ?? 512;
+        $passphrase = $this->option('passphrase');
+
+        $filenamePublic = sprintf('%s/jwt-%s-%d-public.pem', $directory, $algo, $bits);
+        $filenamePrivate = sprintf('%s/jwt-%s-%d-private.pem', $directory, $algo, $bits);
+
+        if (true === file_exists($filenamePrivate)) {
+            $this->warn('Private cert already exists');
+
+            if (!$force) {
+                $this->warn('Aborting');
+                return;
+            }
+        }
+
+        if (true === file_exists($filenamePublic)) {
+            $this->warn('Public cert already exists');
+
+            if (!$force) {
+                $this->warn('Aborting');
+                return;
+            }
+        }
+
+        switch ($algo) {
+            case 'rsa': {
+                    $keyType = OPENSSL_KEYTYPE_RSA;
+                    $algoIdentifier = sprintf('RS%d', $shaVariant);
+                    break;
+                }
+            case 'ec': {
+                    $keyType = OPENSSL_KEYTYPE_EC;
+                    $algoIdentifier = sprintf('ES%d', $shaVariant);
+                    break;
+                }
+            default: {
+                    $this->error('Unknown algorithm');
+                    return -1;
+                }
+        }
+
+        $config = array(
+            "digest_alg" => sprintf('sha%d', $shaVariant),
+            "private_key_bits" => $bits,
+            "private_key_type" => $keyType,
+        );
+
+        // Create the private and public key
+        $res = openssl_pkey_new($config);
+
+        // Extract the private key from $res to $privKey
+        openssl_pkey_export($res, $privKey, $passphrase);
+
+        // Extract the public key from $res to $pubKey
+        $pubKey = openssl_pkey_get_details($res);
+        $pubKey = $pubKey["key"];
+
+        file_put_contents($filenamePrivate, $privKey);
+        file_put_contents($filenamePublic, $pubKey);
+
+        if (false === file_exists($envFilePath = $this->envPath())) {
+            $this->error('.env file missing');
+            return -1;
+        }
+
+        $this->updateEnvEntry($envFilePath, 'JWT_ALGO', $algoIdentifier);
+        $this->updateEnvEntry($envFilePath, 'JWT_PRIVATE_KEY', sprintf("file://../%s", $filenamePrivate));
+        $this->updateEnvEntry($envFilePath, 'JWT_PUBLIC_KEY', sprintf("file://../%s", $filenamePublic));
+        $this->updateEnvEntry($envFilePath, 'JWT_PASSPHRASE', sprintf("file://../%s", $passphrase ?? ''));
+    }
+
+    function updateEnvEntry(string $filepath, string $key, $value)
+    {
+        if (false === Str::contains(file_get_contents($filepath), $key)) {
+            // create new entry
+            file_put_contents(
+                $filepath,
+                PHP_EOL . "{$key}={$value}" . PHP_EOL,
+                FILE_APPEND
+            );
+        } else {
+            file_put_contents(
+                $filepath,
+                str_replace(
+                    "/{$key}=.*/",
+                    "{$key}={$value}",
+                    file_get_contents($filepath)
+                )
+            );
+        }
+    }
+}

--- a/src/Console/JWTGenerateCertCommand.php
+++ b/src/Console/JWTGenerateCertCommand.php
@@ -14,10 +14,11 @@ class JWTGenerateCertCommand extends Command
      */
     protected $signature = 'jwt:generate-certs 
         {--force : Override certificates if existing} 
-        {--algo : Algorithm (rsa/ec)} 
-        {--bits= : Key length (rsa:1024,2048,4096,8192;ec:160,224,256,384,512} 
+        {--algo= : Algorithm (rsa/ec)} 
+        {--bits= : RSA-Key length (1024,2048,4096,8192} 
         {--sha= : SHA-variant (1,224,256,384,512)} 
         {--dir= : Directory where the certificates should be placed} 
+        {--curve= : EC-Curvename (e.g. secp384r1, prime256v1 )}
         {--passphrase= : Passphrase}';
 
     /**
@@ -40,6 +41,7 @@ class JWTGenerateCertCommand extends Command
         $bits = $this->option('bits') ? intval($this->option('bits')) : 4096;
         $shaVariant = $this->option('sha') ? intval($this->option('sha')) : 512;
         $passphrase = $this->option('passphrase') ? $this->option('passphrase') : null;
+        $curve = $this->option('curve') ? $this->option('curve') : 'prime256v1';
 
         $filenamePublic = sprintf('%s/jwt-%s-%d-public.pem', $directory, $algo, $bits);
         $filenamePrivate = sprintf('%s/jwt-%s-%d-private.pem', $directory, $algo, $bits);
@@ -81,9 +83,10 @@ class JWTGenerateCertCommand extends Command
 
         // Create the private and public key
         $res = openssl_pkey_new([
-            "digest_alg" => sprintf('sha%d', $shaVariant),
-            "private_key_bits" => $bits,
-            "private_key_type" => $keyType,
+            'digest_alg' => sprintf('sha%d', $shaVariant),
+            'private_key_bits' => $bits,
+            'private_key_type' => $keyType,
+            'curve_name' => $curve,
         ]);
 
         // Extract the private key from $res to $privKey

--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -67,6 +67,8 @@ class JWTGenerateSecretCommand extends Command
 
                 return false;
             }
+
+            return true;
         });
 
         if($updated) {

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Support\ServiceProvider;
 use Namshi\JOSE\JWS;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Factory as ClaimFactory;
+use PHPOpenSourceSaver\JWTAuth\Console\JWTGenerateCertCommand;
 use PHPOpenSourceSaver\JWTAuth\Console\JWTGenerateSecretCommand;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT as JWTContract;
@@ -78,9 +79,12 @@ abstract class AbstractServiceProvider extends ServiceProvider
         $this->registerPayloadValidator();
         $this->registerClaimFactory();
         $this->registerPayloadFactory();
-        $this->registerJWTCommand();
+        $this->registerJWTCommands();
 
-        $this->commands('tymon.jwt.secret');
+        $this->commands([
+            'tymon.jwt.secret',
+            'tymon.jwt.cert'
+        ]);
     }
 
     /**
@@ -317,9 +321,10 @@ abstract class AbstractServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerJWTCommand()
+    protected function registerJWTCommands()
     {
         $this->app->singleton('tymon.jwt.secret', fn () => new JWTGenerateSecretCommand());
+        $this->app->singleton('tymon.jwt.cert', fn () => new JWTGenerateCertCommand());
     }
 
     /**

--- a/tests/Providers/LaravelServiceProviderTest.php
+++ b/tests/Providers/LaravelServiceProviderTest.php
@@ -16,6 +16,7 @@ use Orchestra\Testbench\TestCase;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Factory as ClaimFactory;
 use PHPOpenSourceSaver\JWTAuth\Console\JWTGenerateSecretCommand;
+use PHPOpenSourceSaver\JWTAuth\Console\JWTGenerateCertCommand;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT as JWTContract;
@@ -233,10 +234,17 @@ class LaravelServiceProviderTest extends TestCase
         $this->assertInstanceOf(Factory::class, $factory);
     }
 
-    public function testRegisterJWTCommand()
+    public function testRegisterJWTGenerateSecretCommand()
     {
         /** @var Factory $factory */
         $factory = $this->app->make('tymon.jwt.secret');
         $this->assertInstanceOf(JWTGenerateSecretCommand::class, $factory);
+    }
+
+    public function testRegisterJWTGenerateCertCommand()
+    {
+        /** @var Factory $factory */
+        $factory = $this->app->make('tymon.jwt.cert');
+        $this->assertInstanceOf(JWTGenerateCertCommand::class, $factory);
     }
 }


### PR DESCRIPTION
## Description

A new command was added, that can be used for generating certificates and updating the env-file. 
Common code between the command for generating secrets and certs has been refactored into a trait. 

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
