### PR TITLE
FIX: auth header not ignoring other auth schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
 
+## [1.4.3] - 2022-05-19
+
+### Fixed
+- Auth header not ignoring other auth schemes
+
 ## [1.4.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
 
-## [1.4.3] - 2022-05-19
-
 ### Fixed
 - Auth header not ignoring other auth schemes
 

--- a/src/Http/Parser/AuthHeaders.php
+++ b/src/Http/Parser/AuthHeaders.php
@@ -50,11 +50,19 @@ class AuthHeaders implements ParserContract
     {
         $header = $request->headers->get($this->header) ?: $this->fromAltHeaders($request);
 
-        if ($header) {
-            $start = strlen($this->prefix);
+        if ($header !== null) {
+            $position = strripos($header, $this->prefix);
 
-            return trim(substr($header, $start));
+            if ($position !== false) {
+                $header = substr($header, $position + strlen($this->prefix));
+
+                return trim(
+                    strpos($header, ',') !== false ? strstr($header, ',', true) : $header
+                );
+            }
         }
+
+        return null;
     }
 
     /**

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -551,4 +551,42 @@ class ParserTest extends AbstractTestCase
         $this->assertNull($parser->parseToken());
         $this->assertFalse($parser->hasToken());
     }
+
+    /** @test */
+    public function itShouldIgnoreTokensWithoutPrefixes()
+    {
+        $request = Request::create('foo', 'POST');
+        $request->headers->set('Authorization', 'Basic OnBhc3N3b3Jk');
+
+        $parser = new Parser($request);
+
+        $parser->setChain([
+            new QueryString,
+            new InputSource,
+            new AuthHeaders,
+            new RouteParams,
+        ]);
+
+        $this->assertNull($parser->parseToken());
+        $this->assertFalse($parser->hasToken());
+    }
+
+    /** @test */
+    public function itShouldParseMultipleAuthHeaders()
+    {
+        $request = Request::create('foo', 'POST');
+        $request->headers->set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5, Basic OnBhc3N3b3Jk');
+
+        $parser = new Parser($request);
+
+        $parser->setChain([
+            new QueryString,
+            new InputSource,
+            new AuthHeaders,
+            new RouteParams,
+        ]);
+
+        $this->assertSame($parser->parseToken(), 'eyJhbGciOiJIUzI1NiIsInR5');
+        $this->assertTrue($parser->hasToken());
+    }
 }

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -556,7 +556,7 @@ class ParserTest extends AbstractTestCase
     public function itShouldIgnoreTokensWithoutPrefixes()
     {
         $request = Request::create('foo', 'POST');
-        $request->headers->set('Authorization', 'Basic OnBhc3N3b3Jk');
+        $request->headers->set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5');
 
         $parser = new Parser($request);
 

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -532,4 +532,23 @@ class ParserTest extends AbstractTestCase
         $this->assertSame($parser->parseToken(), 'foobar');
         $this->assertTrue($parser->hasToken());
     }
+
+    /** @test */
+    public function itShouldIgnoreNonBearerTokens()
+    {
+        $request = Request::create('foo', 'POST');
+        $request->headers->set('Authorization', 'Basic OnBhc3N3b3Jk');
+
+        $parser = new Parser($request);
+
+        $parser->setChain([
+            new QueryString,
+            new InputSource,
+            new AuthHeaders,
+            new RouteParams,
+        ]);
+
+        $this->assertNull($parser->parseToken());
+        $this->assertFalse($parser->hasToken());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/139

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
