### PR TITLE
fixed replacing of values using regex

### DIFF
--- a/src/Console/EnvHelperTrait.php
+++ b/src/Console/EnvHelperTrait.php
@@ -47,7 +47,7 @@ trait EnvHelperTrait
                 // update existing entry
                 file_put_contents(
                     $filepath,
-                    str_replace(
+                    preg_replace(
                         "/{$key}=.*/",
                         "{$key}={$value}",
                         file_get_contents($filepath)


### PR DESCRIPTION
Fixed the env-helper-trait to replace values in .env file using regex

## Description

`preg_replace` is used instead of `str_replace` to support regex.

## Checklist:

- [ ] I've added tests for my changes or tests are not applicable
- [ ] I've changed documentations or changes are not required
- [ ] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
