### PR TITLE
added parameter ask-passphrase to generate-cert command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can find and compare releases at the GitHub release page.
 
 ### Fixed
 - Auth header not ignoring other auth schemes
+- Added `ask-passphrase` parameter to generating certs command
 
 ## [1.4.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
 
+### Added
+- Added `ask-passphrase` parameter to generating certs command
+
 ### Fixed
 - Auth header not ignoring other auth schemes
-- Added `ask-passphrase` parameter to generating certs command
 
 ## [1.4.2]
 

--- a/docs/generate-secrets.md
+++ b/docs/generate-secrets.md
@@ -1,0 +1,49 @@
+### Generate secret key
+
+I have included a helper command to generate a key for you:
+
+```bash
+php artisan jwt:secret
+```
+
+This will update your `.env` file with something like `JWT_SECRET=foobar`
+
+It is the key that will be used to sign your tokens. How that happens exactly will depend
+on the algorithm that you choose to use.
+
+### Generate certificate
+
+For generating certificates the command 
+
+```bash
+php artisan jwt:generate-certs
+```
+
+can be used. The `.env` file will be updated, to use the newly created certificates. 
+
+The command accepts for following paramters
+
+| name | description |
+|---|---|
+| force | override existing certificates |
+| algo | Either rsa or ec |
+| bits | Key length for rsa |
+| curve | Curve to be used for ec |
+| sha | Hashing algorithm |
+| passphrase | Passphrase for the cert |
+| ask-passphrase | Ask for passphrase instead of passing as parameter |
+| dir | Folder to place the certificates |
+
+#### Examples 
+
+Generating a 4096 bit rsa certificate with sha 512
+
+```bash
+php artisan jwt:generate-certs --force --algo=rsa --bits=4096 --sha=512
+```
+
+Generating a ec certificate with prime256v1-curve and sha 512
+
+```bash
+php artisan jwt:generate-certs --force --algo=ec --curve=prime256v1 --sha=512
+```

--- a/docs/laravel-installation.md
+++ b/docs/laravel-installation.md
@@ -33,53 +33,6 @@ php artisan vendor:publish --provider="PHPOpenSourceSaver\JWTAuth\Providers\Lara
 
 You should now have a `config/jwt.php` file that allows you to configure the basics of this package.
 
--------------------------------------------------------------------------------
+### Generate secrets
 
-### Generate secret key
-
-I have included a helper command to generate a key for you:
-
-```bash
-php artisan jwt:secret
-```
-
-This will update your `.env` file with something like `JWT_SECRET=foobar`
-
-It is the key that will be used to sign your tokens. How that happens exactly will depend
-on the algorithm that you choose to use.
-
-### Generate certificate
-
-For generating certificates the command 
-
-```bash
-php artisan jwt:generate-certs
-```
-
-can be used. The `.env` file will be updated, to use the newly created certificates. 
-
-The command accepts for following paramters
-
-| name | description |
-|---|---|
-| force | override existing certificates |
-| algo | Either rsa or ec |
-| bits | Key length for rsa |
-| curve | Curve to be used for ec |
-| sha | Hashing algorithm |
-| passphrase | Passphrase for the cert |
-| dir | Folder to place the certificates |
-
-#### Examples 
-
-Generating a 4096 bit rsa certificate with sha 512
-
-```bash
-php artisan jwt:generate-certs --force --algo=rsa --bits=4096 --sha=512
-```
-
-Generating a ec certificate with prime256v1-curve and sha 512
-
-```bash
-php artisan jwt:generate-certs --force --algo=ec --curve=prime256v1 --sha=512
-```
+For generating secrets have a look at [generate secrets](generate-secrets.md).

--- a/docs/lumen-installation.md
+++ b/docs/lumen-installation.md
@@ -42,51 +42,6 @@ $app->routeMiddleware([
 
 -------------------------------------------------------------------------------
 
-### Generate secret key
+### Generate secrets
 
-I have included a helper command to generate a key for you:
-
-```bash
-php artisan jwt:secret
-```
-
-This will update your `.env` file with something like `JWT_SECRET=foobar`
-
-It is the key that will be used to sign your tokens. How that happens exactly will depend
-on the algorithm that you choose to use.
-
-### Generate certificate
-
-For generating certificates the command 
-
-```bash
-php artisan jwt:generate-certs
-```
-
-can be used. The `.env` file will be updated, to use the newly created certificates. 
-
-The command accepts for following paramters
-
-| name | description |
-|---|---|
-| force | override existing certificates |
-| algo | Either rsa or ec |
-| bits | Key length for rsa |
-| curve | Curve to be used for ec |
-| sha | Hashing algorithm |
-| passphrase | Passphrase for the cert |
-| dir | Folder to place the certificates |
-
-#### Examples 
-
-Generating a 4096 bit rsa certificate with sha 512
-
-```bash
-php artisan jwt:generate-certs --force --algo=rsa --bits=4096 --sha=512
-```
-
-Generating a ec certificate with prime256v1-curve and sha 512
-
-```bash
-php artisan jwt:generate-certs --force --algo=ec --curve=prime256v1 --sha=512
-```
+For generating secrets have a look at [generate secrets](generate-secrets.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - Home: index.md
   - Laravel Installation: laravel-installation.md
   - Lumen Installation (incomplete): lumen-installation.md
+  - Generate Secrets: generate-secrets.md
   - Quick start: quick-start.md
   - Auth guard: auth-guard.md
   - Configuration: configuration.md

--- a/src/Console/JWTGenerateCertCommand.php
+++ b/src/Console/JWTGenerateCertCommand.php
@@ -19,7 +19,8 @@ class JWTGenerateCertCommand extends Command
         {--sha= : SHA-variant (1,224,256,384,512)} 
         {--dir= : Directory where the certificates should be placed} 
         {--curve= : EC-Curvename (e.g. secp384r1, prime256v1 )}
-        {--passphrase= : Passphrase}';
+        {--passphrase= : Passphrase}
+        {--ask-passphrase : Enter passphrase instead passing as argument}';
 
     /**
      * The console command description.
@@ -40,8 +41,13 @@ class JWTGenerateCertCommand extends Command
         $algo = $this->option('algo') ? $this->option('algo') : 'rsa';
         $bits = $this->option('bits') ? intval($this->option('bits')) : 4096;
         $shaVariant = $this->option('sha') ? intval($this->option('sha')) : 512;
-        $passphrase = $this->option('passphrase') ? $this->option('passphrase') : null;
         $curve = $this->option('curve') ? $this->option('curve') : 'prime256v1';
+
+        if($this->option('ask-passphrase')) {
+            $passphrase = $this->secret('Passphrase');
+        } else {
+            $passphrase = $this->option('passphrase') ? $this->option('passphrase') : null;
+        }
 
         $filenamePublic = sprintf('%s/jwt-%s-%d-public.pem', $directory, $algo, $bits);
         $filenamePrivate = sprintf('%s/jwt-%s-%d-private.pem', $directory, $algo, $bits);
@@ -98,7 +104,7 @@ class JWTGenerateCertCommand extends Command
 
         // save certificates to disk
         if (false === is_dir($directory)) {
-            mkdir($directory);
+            mkdir($directory, 0777, true);
         }
 
         file_put_contents($filenamePrivate, $privKey);


### PR DESCRIPTION
Added parameter `ask-passphrase` to generate-cert command additionally to passing the passphrase as parameter.

## Description

Added parameter `ask-passphrase` to generate-cert command. 

## Checklist:

- [ ] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
