### PR TITLE
changed default value for enabling the throwing of the blacklisting e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can find and compare releases at the GitHub release page.
 ## [Unreleased]
 
 ### Fixed
+- Default config value for `show_black_list_exception` changed to true
 - Auth header not ignoring other auth schemes
 
 ## [1.4.2]

--- a/config/config.php
+++ b/config/config.php
@@ -234,7 +234,7 @@ return [
     |
     */
 
-    'show_black_list_exception' => env('JWT_SHOW_BLACKLIST_EXCEPTION', 0),
+    'show_black_list_exception' => env('JWT_SHOW_BLACKLIST_EXCEPTION', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/DefaultConfigValuesTest.php
+++ b/tests/DefaultConfigValuesTest.php
@@ -107,7 +107,7 @@ class DefaultConfigValuesTest extends AbstractTestCase
     /** @test */
     public function showBlackListExceptionShouldBeDisabled()
     {
-        $this->assertEquals(0, $this->configuration['show_black_list_exception']);
+        $this->assertTrue($this->configuration['show_black_list_exception']);
     }
 
     /** @test */

--- a/tests/Providers/LaravelServiceProviderTest.php
+++ b/tests/Providers/LaravelServiceProviderTest.php
@@ -152,12 +152,12 @@ class LaravelServiceProviderTest extends TestCase
         /** @var Manager $manager */
         $manager = $this->app->make('tymon.jwt.manager');
         $this->assertInstanceOf(Manager::class, $manager);
-        $this->assertFalse($manager->getBlackListExceptionEnabled());
+        $this->assertTrue($manager->getBlackListExceptionEnabled());
 
-        $this->app['config']->set('jwt.show_black_list_exception', true);
+        $this->app['config']->set('jwt.show_black_list_exception', false);
         $this->app->forgetInstance('tymon.jwt.manager');
         $manager = $this->app->make('tymon.jwt.manager');
-        $this->assertTrue($manager->getBlackListExceptionEnabled());
+        $this->assertFalse($manager->getBlackListExceptionEnabled());
     }
 
     public function testRegisterTokenParser()


### PR DESCRIPTION
The default value in the config for enabling the throwing of blacklisting exception was changed to true.

## Description

The default value was changed from false to true. The majority of the users want the exception to be thrown. 

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [ ] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
