### PR TITLE
fix: overwrite custom claims from token

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -177,8 +177,8 @@ class Manager
 
         // persist the relevant claims
         return array_merge(
-            $this->customClaims,
             $persistentClaims,
+            $this->customClaims,
             [
                 'sub' => $payload['sub'],
                 'iat' => $payload['iat'],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

There is a problem. When a user is authorized, his data is written to getJWTCustomClaims. But if the user changes them during the session, the data in the token remains old when the token is updated. The subsequent update takes the data from the token and overwrites the new user data. This causes the token to contain irrelevant data. If you exit the session and login again, the data is taken up to date.

```
public function getJWTCustomClaims()
    {
        return [
            'locale' => $this->locale ?? config('app.fallback_locale'),
        ];
    }
```

