### PR TITLE
FEAT: custom TTLs for each guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
 
+### Added
+- Different TTL configurations for each guard
+
 ## [2.0.0] 2022-09-08
 - No changes to 2.0.0-RC1
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,8 +3,45 @@ I won't go through all of the options here since [the file itself](https://githu
 
 First up is:
 
-```
+```php
 'secret' => env('JWT_SECRET'),
 ```
+
+### Configuring Custom TTL for Auth Guards
+
+To set a custom TTL (Time To Live) for each `jwt` guard, you can follow these steps:
+
+For each guard that you want to have its own TTL, add the `ttl` option inside the guard's configuration.
+
+Setting a custom TTL for a guard allows it to use its specific `ttl` value rather than the global `ttl` value defined in `config/jwt.php`. This can be particularly useful when using multiple guards for different providers and you wish to set different TTLs for each one.
+
+Below is an example of how you can configure guards with their respective TTLs:
+
+```php
+'guards' => [
+    'customers' => [
+        'driver' => 'jwt',
+        'provider' => 'customers',
+        'ttl' => env('JWT_CUSTOMERS_TTL', 15), // Custom TTL for 'customers' guard (15 minutes)
+    ],
+    'administrators' => [
+        'driver' => 'jwt',
+        'provider' => 'administrators',
+        'ttl' => null, // 'administrators' guard has no expiration
+    ],
+    // if no 'ttl' is set, it will use the 'ttl' value in `config/jwt.php`
+    'users' => [
+        'driver' => 'jwt',
+        'provider' => 'users',
+    ],
+],
+```
+
+In the above configuration example:
+
+1. The `customers` guard will have a custom TTL of 15 minutes.
+2. The `administrators` guard has a `ttl` set to `null`, indicating that it will have no expiration, meaning the token will never automatically expire for this guard.
+3. Guards that do not have `ttl` inside the guard config will use the default `ttl` in `config/jwt.php`
+4. By setting custom TTLs for different guards, you can have fine-grained control over token expiration and enhance the security and flexibility of your authentication system.
 
 Coming soon...

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -209,7 +209,7 @@ class Factory
     /**
      * Helper to get the ttl.
      *
-     * @return int
+     * @return int|null
      */
     public function getTTL()
     {

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -218,7 +218,7 @@ class JWTGuard implements Guard
      * Create a new token by User id.
      *
      * @param mixed $id
-     * 
+     *
      * @return string|null
      */
     public function tokenById($id)
@@ -248,7 +248,7 @@ class JWTGuard implements Guard
      * Log the given User into the application.
      *
      * @param mixed $id
-     * 
+     *
      * @return bool
      */
     public function onceUsingId($id)

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -12,6 +12,7 @@
 
 namespace PHPOpenSourceSaver\JWTAuth;
 
+use BadMethodCallException;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Auth\Events\Failed;
@@ -100,9 +101,9 @@ class JWTGuard implements Guard
         }
 
         if (
-            $this->jwt->setRequest($this->request)->getToken()
-            && ($payload = $this->jwt->check(true))
-            && $this->validateSubject()
+            $this->jwt->setRequest($this->request)->getToken() &&
+            ($payload = $this->jwt->check(true)) &&
+            $this->validateSubject()
         ) {
             return $this->user = $this->provider->retrieveById($payload['sub']);
         }
@@ -216,6 +217,8 @@ class JWTGuard implements Guard
     /**
      * Create a new token by User id.
      *
+     * @param mixed $id
+     * 
      * @return string|null
      */
     public function tokenById($id)
@@ -244,6 +247,8 @@ class JWTGuard implements Guard
     /**
      * Log the given User into the application.
      *
+     * @param mixed $id
+     * 
      * @return bool
      */
     public function onceUsingId($id)
@@ -259,6 +264,8 @@ class JWTGuard implements Guard
 
     /**
      * Alias for onceUsingId.
+     * 
+     * @param mixed $id
      *
      * @return bool
      */
@@ -418,6 +425,7 @@ class JWTGuard implements Guard
     /**
      * Determine if the user matches the credentials.
      *
+     * @param mixed $user
      * @param array $credentials
      *
      * @return bool
@@ -568,7 +576,9 @@ class JWTGuard implements Guard
      * @param string $method
      * @param array  $parameters
      *
-     * @throws \BadMethodCallException
+     * @return mixed
+     *
+     * @throws BadMethodCallException
      */
     public function __call($method, $parameters)
     {
@@ -580,6 +590,6 @@ class JWTGuard implements Guard
             return $this->macroCall($method, $parameters);
         }
 
-        throw new \BadMethodCallException("Method [$method] does not exist.");
+        throw new BadMethodCallException("Method [$method] does not exist.");
     }
 }

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -264,7 +264,7 @@ class JWTGuard implements Guard
 
     /**
      * Alias for onceUsingId.
-     * 
+     *
      * @param mixed $id
      *
      * @return bool

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth;
 
-use BadMethodCallException;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Auth\Events\Failed;
@@ -101,9 +100,9 @@ class JWTGuard implements Guard
         }
 
         if (
-            $this->jwt->setRequest($this->request)->getToken() &&
-            ($payload = $this->jwt->check(true)) &&
-            $this->validateSubject()
+            $this->jwt->setRequest($this->request)->getToken()
+            && ($payload = $this->jwt->check(true))
+            && $this->validateSubject()
         ) {
             return $this->user = $this->provider->retrieveById($payload['sub']);
         }
@@ -217,8 +216,6 @@ class JWTGuard implements Guard
     /**
      * Create a new token by User id.
      *
-     * @param mixed $id
-     *
      * @return string|null
      */
     public function tokenById($id)
@@ -247,8 +244,6 @@ class JWTGuard implements Guard
     /**
      * Log the given User into the application.
      *
-     * @param mixed $id
-     *
      * @return bool
      */
     public function onceUsingId($id)
@@ -264,8 +259,6 @@ class JWTGuard implements Guard
 
     /**
      * Alias for onceUsingId.
-     *
-     * @param mixed $id
      *
      * @return bool
      */
@@ -318,6 +311,16 @@ class JWTGuard implements Guard
         $this->jwt->setToken($token);
 
         return $this;
+    }
+
+    /**
+     * Get the token ttl.
+     *
+     * @return int|null
+     */
+    public function getTTL()
+    {
+        return $this->jwt->factory()->getTTL();
     }
 
     /**
@@ -415,7 +418,6 @@ class JWTGuard implements Guard
     /**
      * Determine if the user matches the credentials.
      *
-     * @param mixed $user
      * @param array $credentials
      *
      * @return bool
@@ -566,9 +568,7 @@ class JWTGuard implements Guard
      * @param string $method
      * @param array  $parameters
      *
-     * @return mixed
-     *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      */
     public function __call($method, $parameters)
     {
@@ -580,6 +580,6 @@ class JWTGuard implements Guard
             return $this->macroCall($method, $parameters);
         }
 
-        throw new BadMethodCallException("Method [$method] does not exist.");
+        throw new \BadMethodCallException("Method [$method] does not exist.");
     }
 }

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -13,6 +13,7 @@
 namespace PHPOpenSourceSaver\JWTAuth\Providers;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use Namshi\JOSE\JWS;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
@@ -102,6 +103,12 @@ abstract class AbstractServiceProvider extends ServiceProvider
                 $app['request'],
                 $app['events']
             );
+
+            if (Arr::has($config, 'ttl')) {
+                $guard->setTTL(Arr::get($config, 'ttl'));
+            } else {
+                $guard->setTTL($app->make('config')->get('jwt.ttl'));
+            }
 
             $app->refresh('request', $guard, 'setRequest');
 
@@ -333,8 +340,6 @@ abstract class AbstractServiceProvider extends ServiceProvider
      *
      * @param Application $app
      * @param string      $key
-     *
-     * @return mixed
      */
     protected function getConfigInstance($app, $key)
     {


### PR DESCRIPTION
## Description

1. Adds the ability to optionally define a custom TTL for each guard.
2. Added a getter for `ttl` at `JWTGuard.php`
3. Added `null` to return type in `getTTL()` at `Factory.php` 

Fixes #164

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
