### PR TITLE
Fix misc. Github Action warning

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -24,12 +24,12 @@ jobs:
 
       - name: Determine composer cache directory
         id: composer-cache
-        run: echo "::set-output name=directory::$(composer config cache-dir)"
+        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.directory }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
           restore-keys: |
             composer-${{ runner.os }}-

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -27,7 +27,7 @@ jobs:
       COMPOSER_NO_INTERACTION: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -104,7 +104,7 @@ jobs:
           composer require "vlucas/phpdotenv:${{ matrix.dotenv }}" --no-interaction --no-progress --no-update --dev
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-${{ hashFiles('composer.json') }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -121,9 +121,9 @@ jobs:
         run: composer test:ci
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         if: matrix.coverage == 'xdebug'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          yml: ./codecov.yml
+          files: ./coverage.xml
+          codecov_yml_path: ./codecov.yml

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Set Minimum PHP 8.0 Versions
         run: composer require phpunit/phpunit:^9.4 --no-interaction --no-progress --no-update

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -187,8 +187,6 @@ class Blacklist
 
     /**
      * Get the unique key held within the blacklist.
-     *
-     * @return mixed
      */
     public function getKey(Payload $payload)
     {

--- a/src/Claims/Audience.php
+++ b/src/Claims/Audience.php
@@ -14,8 +14,5 @@ namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class Audience extends Claim
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'aud';
 }

--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -14,11 +14,10 @@ namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use JsonSerializable;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Claim as ClaimContract;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
 
-abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializable
+abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSerializable
 {
     /**
      * The claim name.
@@ -29,14 +28,10 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
 
     /**
      * The claim value.
-     *
-     * @var mixed
      */
     private $value;
 
     /**
-     * @param mixed $value
-     *
      * @return void
      *
      * @throws InvalidClaimException
@@ -49,11 +44,9 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Set the claim value, and call a validate method.
      *
-     * @param mixed $value
+     * @return $this
      *
      * @throws InvalidClaimException
-     *
-     * @return $this
      */
     public function setValue($value)
     {
@@ -64,8 +57,6 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
 
     /**
      * Get the claim value.
-     *
-     * @return mixed
      */
     public function getValue()
     {
@@ -99,8 +90,6 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Validate the claim in a standalone Claim context.
      *
-     * @param mixed $value
-     *
      * @return bool
      */
     public function validateCreate($value)
@@ -133,8 +122,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, JsonSerializ
     /**
      * Checks if the value matches the claim.
      *
-     * @param mixed $value
-     * @param bool  $strict
+     * @param bool $strict
      *
      * @return bool
      */

--- a/src/Claims/Collection.php
+++ b/src/Claims/Collection.php
@@ -20,8 +20,6 @@ class Collection extends IlluminateCollection
     /**
      * Create a new collection.
      *
-     * @param mixed $items
-     *
      * @return void
      */
     public function __construct($items = [])
@@ -33,11 +31,10 @@ class Collection extends IlluminateCollection
      * Get a Claim instance by it's unique name.
      *
      * @param string $name
-     * @param mixed  $default
      *
      * @return Claim
      */
-    public function getByClaimName($name, callable $callback = null, $default = null)
+    public function getByClaimName($name, ?callable $callback = null, $default = null)
     {
         return $this->filter(function (Claim $claim) use ($name) {
             return $claim->getName() === $name;
@@ -69,8 +66,6 @@ class Collection extends IlluminateCollection
     /**
      * Determine if the Collection contains all of the given keys.
      *
-     * @param mixed $claims
-     *
      * @return bool
      */
     public function hasAllClaims($claims)
@@ -90,9 +85,6 @@ class Collection extends IlluminateCollection
         })->toArray();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getArrayableItems($items)
     {
         return $this->sanitizeClaims($items);
@@ -100,8 +92,6 @@ class Collection extends IlluminateCollection
 
     /**
      * Ensure that the given claims array is keyed by the claim name.
-     *
-     * @param mixed $items
      *
      * @return array
      */

--- a/src/Claims/Custom.php
+++ b/src/Claims/Custom.php
@@ -18,7 +18,6 @@ class Custom extends Claim
 {
     /**
      * @param string $name
-     * @param mixed  $value
      *
      * @return void
      *

--- a/src/Claims/DatetimeTrait.php
+++ b/src/Claims/DatetimeTrait.php
@@ -12,8 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
-use DateInterval;
-use DateTimeInterface;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
 use PHPOpenSourceSaver\JWTAuth\Support\Utils;
 
@@ -29,28 +27,23 @@ trait DatetimeTrait
     /**
      * Set the claim value, and call a validate method.
      *
-     * @param mixed $value
+     * @return $this
      *
      * @throws InvalidClaimException
-     *
-     * @return $this
      */
     public function setValue($value)
     {
-        if ($value instanceof DateInterval) {
+        if ($value instanceof \DateInterval) {
             $value = Utils::now()->add($value);
         }
 
-        if ($value instanceof DateTimeInterface) {
+        if ($value instanceof \DateTimeInterface) {
             $value = $value->getTimestamp();
         }
 
         return parent::setValue($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function validateCreate($value)
     {
         if (!is_numeric($value)) {
@@ -63,8 +56,6 @@ trait DatetimeTrait
     /**
      * Determine whether the value is in the future.
      *
-     * @param mixed $value
-     *
      * @return bool
      */
     protected function isFuture($value)
@@ -74,8 +65,6 @@ trait DatetimeTrait
 
     /**
      * Determine whether the value is in the past.
-     *
-     * @param mixed $value
      *
      * @return bool
      */

--- a/src/Claims/Expiration.php
+++ b/src/Claims/Expiration.php
@@ -18,14 +18,8 @@ class Expiration extends Claim
 {
     use DatetimeTrait;
 
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'exp';
 
-    /**
-     * {@inheritdoc}
-     */
     public function validatePayload()
     {
         if ($this->isPast($this->getValue())) {

--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -69,7 +69,6 @@ class Factory
      * Get the instance of the claim when passing the name and value.
      *
      * @param string $name
-     * @param mixed  $value
      *
      * @return Claim
      *

--- a/src/Claims/IssuedAt.php
+++ b/src/Claims/IssuedAt.php
@@ -22,14 +22,8 @@ class IssuedAt extends Claim
         validateCreate as commonValidateCreate;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'iat';
 
-    /**
-     * {@inheritdoc}
-     */
     public function validateCreate($value)
     {
         $this->commonValidateCreate($value);
@@ -41,9 +35,6 @@ class IssuedAt extends Claim
         return $value;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function validatePayload()
     {
         if ($this->isFuture($this->getValue())) {
@@ -51,9 +42,6 @@ class IssuedAt extends Claim
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function validateRefresh($refreshTTL)
     {
         if ($this->isPast($this->getValue() + $refreshTTL * 60)) {

--- a/src/Claims/Issuer.php
+++ b/src/Claims/Issuer.php
@@ -14,8 +14,5 @@ namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class Issuer extends Claim
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'iss';
 }

--- a/src/Claims/JwtId.php
+++ b/src/Claims/JwtId.php
@@ -14,8 +14,5 @@ namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class JwtId extends Claim
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'jti';
 }

--- a/src/Claims/NotBefore.php
+++ b/src/Claims/NotBefore.php
@@ -18,14 +18,9 @@ class NotBefore extends Claim
 {
     use DatetimeTrait;
 
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'nbf';
 
     /**
-     * {@inheritdoc}
-     *
      * @throws TokenInvalidException
      */
     public function validatePayload()

--- a/src/Claims/Subject.php
+++ b/src/Claims/Subject.php
@@ -14,8 +14,5 @@ namespace PHPOpenSourceSaver\JWTAuth\Claims;
 
 class Subject extends Claim
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'sub';
 }

--- a/src/Console/EnvHelperTrait.php
+++ b/src/Console/EnvHelperTrait.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Console;
 
-use Closure;
 use Illuminate\Support\Str;
 
 trait EnvHelperTrait
@@ -30,7 +29,7 @@ trait EnvHelperTrait
      *
      * @param string|int $value
      */
-    public function updateEnvEntry(string $key, $value, Closure $confirmOnExisting = null): bool
+    public function updateEnvEntry(string $key, $value, ?\Closure $confirmOnExisting = null): bool
     {
         $filepath = $this->envPath();
 

--- a/src/Contracts/Claim.php
+++ b/src/Contracts/Claim.php
@@ -19,18 +19,14 @@ interface Claim
     /**
      * Set the claim value, and call a validate method.
      *
-     * @param mixed $value
+     * @return $this
      *
      * @throws InvalidClaimException
-     *
-     * @return $this
      */
     public function setValue($value);
 
     /**
      * Get the claim value.
-     *
-     * @return mixed
      */
     public function getValue();
 
@@ -52,8 +48,6 @@ interface Claim
 
     /**
      * Validate the Claim value.
-     *
-     * @param mixed $value
      *
      * @return bool
      */

--- a/src/Contracts/JWTSubject.php
+++ b/src/Contracts/JWTSubject.php
@@ -16,8 +16,6 @@ interface JWTSubject
 {
     /**
      * Get the identifier that will be stored in the subject claim of the JWT.
-     *
-     * @return mixed
      */
     public function getJWTIdentifier();
 

--- a/src/Contracts/Providers/Auth.php
+++ b/src/Contracts/Providers/Auth.php
@@ -16,24 +16,16 @@ interface Auth
 {
     /**
      * Check a user's credentials.
-     *
-     * @return mixed
      */
     public function byCredentials(array $credentials);
 
     /**
      * Authenticate a user via the id.
-     *
-     * @param mixed $id
-     *
-     * @return mixed
      */
     public function byId($id);
 
     /**
      * Get the currently authenticated user.
-     *
-     * @return mixed
      */
     public function user();
 }

--- a/src/Contracts/Providers/Storage.php
+++ b/src/Contracts/Providers/Storage.php
@@ -16,7 +16,6 @@ interface Storage
 {
     /**
      * @param string $key
-     * @param mixed  $value
      * @param int    $minutes
      *
      * @return void
@@ -25,7 +24,6 @@ interface Storage
 
     /**
      * @param string $key
-     * @param mixed  $value
      *
      * @return void
      */
@@ -33,8 +31,6 @@ interface Storage
 
     /**
      * @param string $key
-     *
-     * @return mixed
      */
     public function get($key);
 

--- a/src/Contracts/Validator.php
+++ b/src/Contracts/Validator.php
@@ -17,8 +17,6 @@ interface Validator
     /**
      * Perform some checks on the value.
      *
-     * @param mixed $value
-     *
      * @return void
      */
     public function check($value);

--- a/src/Exceptions/InvalidClaimException.php
+++ b/src/Exceptions/InvalidClaimException.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
-use Exception;
 use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
 
 class InvalidClaimException extends JWTException
@@ -24,7 +23,7 @@ class InvalidClaimException extends JWTException
      *
      * @return void
      */
-    public function __construct(Claim $claim, $code = 0, Exception $previous = null)
+    public function __construct(Claim $claim, $code = 0, ?\Exception $previous = null)
     {
         parent::__construct('Invalid value provided for claim ['.$claim->getName().']', $code, $previous);
     }

--- a/src/Exceptions/JWTException.php
+++ b/src/Exceptions/JWTException.php
@@ -12,12 +12,7 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Exceptions;
 
-use Exception;
-
-class JWTException extends Exception
+class JWTException extends \Exception
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $message = 'An error occurred';
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -116,7 +116,6 @@ class Factory
      * Add a claim to the Payload.
      *
      * @param string $name
-     * @param mixed  $value
      *
      * @return $this
      */

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
-use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
@@ -23,11 +22,9 @@ class Authenticate extends BaseMiddleware
      *
      * @param Request $request
      *
-     * @return mixed
-     *
      * @throws UnauthorizedHttpException
      */
-    public function handle($request, Closure $next)
+    public function handle($request, \Closure $next)
     {
         $this->authenticate($request);
 

--- a/src/Http/Middleware/AuthenticateAndRenew.php
+++ b/src/Http/Middleware/AuthenticateAndRenew.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
-use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
@@ -23,11 +22,9 @@ class AuthenticateAndRenew extends BaseMiddleware
      *
      * @param Request $request
      *
-     * @return mixed
-     *
      * @throws UnauthorizedHttpException
      */
-    public function handle($request, Closure $next)
+    public function handle($request, \Closure $next)
     {
         $this->authenticate($request);
 

--- a/src/Http/Middleware/Check.php
+++ b/src/Http/Middleware/Check.php
@@ -12,8 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
-use Closure;
-use Exception;
 use Illuminate\Http\Request;
 
 class Check extends BaseMiddleware
@@ -22,15 +20,13 @@ class Check extends BaseMiddleware
      * Handle an incoming request.
      *
      * @param Request $request
-     *
-     * @return mixed
      */
-    public function handle($request, Closure $next)
+    public function handle($request, \Closure $next)
     {
         if ($this->auth->parser()->setRequest($request)->hasToken()) {
             try {
                 $this->auth->parseToken()->authenticate();
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
             }
         }
 

--- a/src/Http/Middleware/RefreshToken.php
+++ b/src/Http/Middleware/RefreshToken.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Http\Middleware;
 
-use Closure;
 use Illuminate\Http\Request;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
@@ -24,11 +23,9 @@ class RefreshToken extends BaseMiddleware
      *
      * @param Request $request
      *
-     * @return mixed
-     *
      * @throws UnauthorizedHttpException
      */
-    public function handle($request, Closure $next)
+    public function handle($request, \Closure $next)
     {
         $this->checkForToken($request);
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth;
 
-use BadMethodCallException;
 use Illuminate\Http\Request;
 use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
@@ -208,8 +207,6 @@ class JWT
      * Convenience method to get a claim value.
      *
      * @param string $claim
-     *
-     * @return mixed
      */
     public function getClaim($claim)
     {
@@ -392,9 +389,7 @@ class JWT
      * @param string $method
      * @param array  $parameters
      *
-     * @return mixed
-     *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      */
     public function __call($method, $parameters)
     {
@@ -402,6 +397,6 @@ class JWT
             return call_user_func_array([$this->manager, $method], $parameters);
         }
 
-        throw new BadMethodCallException("Method [$method] does not exist.");
+        throw new \BadMethodCallException("Method [$method] does not exist.");
     }
 }

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth;
 
-use BadMethodCallException;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Auth\Events\Failed;
@@ -101,9 +100,9 @@ class JWTGuard implements Guard
         }
 
         if (
-            $this->jwt->setRequest($this->request)->getToken() &&
-            ($payload = $this->jwt->check(true)) &&
-            $this->validateSubject()
+            $this->jwt->setRequest($this->request)->getToken()
+            && ($payload = $this->jwt->check(true))
+            && $this->validateSubject()
         ) {
             return $this->user = $this->provider->retrieveById($payload['sub']);
         }
@@ -217,8 +216,6 @@ class JWTGuard implements Guard
     /**
      * Create a new token by User id.
      *
-     * @param mixed $id
-     *
      * @return string|null
      */
     public function tokenById($id)
@@ -247,8 +244,6 @@ class JWTGuard implements Guard
     /**
      * Log the given User into the application.
      *
-     * @param mixed $id
-     *
      * @return bool
      */
     public function onceUsingId($id)
@@ -264,8 +259,6 @@ class JWTGuard implements Guard
 
     /**
      * Alias for onceUsingId.
-     *
-     * @param mixed $id
      *
      * @return bool
      */
@@ -425,7 +418,6 @@ class JWTGuard implements Guard
     /**
      * Determine if the user matches the credentials.
      *
-     * @param mixed $user
      * @param array $credentials
      *
      * @return bool
@@ -462,7 +454,7 @@ class JWTGuard implements Guard
      *
      * @return JWT
      *
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException
+     * @throws JWTException
      */
     protected function requireToken()
     {
@@ -525,7 +517,7 @@ class JWTGuard implements Guard
     /**
      * Fire the authenticated event.
      *
-     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param Authenticatable $user
      *
      * @return void
      */
@@ -540,8 +532,8 @@ class JWTGuard implements Guard
     /**
      * Fire the login event.
      *
-     * @param \Illuminate\Contracts\Auth\Authenticatable $user
-     * @param bool                                       $remember
+     * @param Authenticatable $user
+     * @param bool            $remember
      *
      * @return void
      */
@@ -557,8 +549,8 @@ class JWTGuard implements Guard
     /**
      * Fire the logout event.
      *
-     * @param \Illuminate\Contracts\Auth\Authenticatable $user
-     * @param bool                                       $remember
+     * @param Authenticatable $user
+     * @param bool            $remember
      *
      * @return void
      */
@@ -576,9 +568,7 @@ class JWTGuard implements Guard
      * @param string $method
      * @param array  $parameters
      *
-     * @return mixed
-     *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      */
     public function __call($method, $parameters)
     {
@@ -590,6 +580,6 @@ class JWTGuard implements Guard
             return $this->macroCall($method, $parameters);
         }
 
-        throw new BadMethodCallException("Method [$method] does not exist.");
+        throw new \BadMethodCallException("Method [$method] does not exist.");
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -94,7 +94,7 @@ class Manager
      *
      * @return Payload
      *
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException
+     * @throws TokenBlacklistedException
      */
     public function decode(Token $token, $checkBlacklist = true)
     {
@@ -106,10 +106,10 @@ class Manager
             ->make();
 
         if (
-            $checkBlacklist &&
-            $this->blacklistEnabled &&
-            $this->getBlackListExceptionEnabled() &&
-            $this->blacklist->has($payload)
+            $checkBlacklist
+            && $this->blacklistEnabled
+            && $this->getBlackListExceptionEnabled()
+            && $this->blacklist->has($payload)
         ) {
             throw new TokenBlacklistedException('The token has been blacklisted');
         }

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -12,20 +12,16 @@
 
 namespace PHPOpenSourceSaver\JWTAuth;
 
-use ArrayAccess;
-use BadMethodCallException;
-use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use JsonSerializable;
 use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\PayloadException;
 use PHPOpenSourceSaver\JWTAuth\Validators\PayloadValidator;
 
-class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerializable
+class Payload implements \ArrayAccess, Arrayable, \Countable, Jsonable, \JsonSerializable
 {
     /**
      * The collection of claims.
@@ -92,10 +88,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
 
     /**
      * Get the payload.
-     *
-     * @param mixed $claim
-     *
-     * @return mixed
      */
     public function get($claim = null)
     {
@@ -192,8 +184,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
     /**
      * Determine if an item exists at an offset.
      *
-     * @param mixed $key
-     *
      * @return bool
      */
     #[\ReturnTypeWillChange]
@@ -204,10 +194,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
 
     /**
      * Get an item at a given offset.
-     *
-     * @param mixed $key
-     *
-     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($key)
@@ -217,9 +203,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
 
     /**
      * Don't allow changing the payload as it should be immutable.
-     *
-     * @param mixed $key
-     * @param mixed $value
      *
      * @throws PayloadException
      */
@@ -257,10 +240,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
 
     /**
      * Invoke the Payload as a callable function.
-     *
-     * @param mixed $claim
-     *
-     * @return mixed
      */
     public function __invoke($claim = null)
     {
@@ -273,9 +252,7 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
      * @param string $method
      * @param array  $parameters
      *
-     * @return mixed
-     *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      */
     public function __call($method, $parameters)
     {
@@ -287,6 +264,6 @@ class Payload implements ArrayAccess, Arrayable, Countable, Jsonable, JsonSerial
             }
         }
 
-        throw new BadMethodCallException(sprintf('The claim [%s] does not exist on the payload.', Str::after($method, 'get')));
+        throw new \BadMethodCallException(sprintf('The claim [%s] does not exist on the payload.', Str::after($method, 'get')));
     }
 }

--- a/src/Providers/Auth/Illuminate.php
+++ b/src/Providers/Auth/Illuminate.php
@@ -47,8 +47,6 @@ class Illuminate implements Auth
     /**
      * Authenticate a user via the id.
      *
-     * @param mixed $id
-     *
      * @return bool
      */
     public function byId($id)
@@ -58,8 +56,6 @@ class Illuminate implements Auth
 
     /**
      * Get the currently authenticated user.
-     *
-     * @return mixed
      */
     public function user()
     {

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -12,8 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Providers\JWT;
 
-use DateTimeImmutable;
-use Exception;
 use Illuminate\Support\Collection;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Configuration;
@@ -36,7 +34,6 @@ use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
-use ReflectionClass;
 
 class Lcobucci extends Provider implements JWT
 {
@@ -139,7 +136,7 @@ class Lcobucci extends Provider implements JWT
             }
 
             return $this->builder->getToken($this->config->signer(), $this->config->signingKey())->toString();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new JWTException('Could not create token: '.$e->getMessage(), $e->getCode(), $e);
         }
     }
@@ -157,7 +154,7 @@ class Lcobucci extends Provider implements JWT
     {
         try {
             $jwt = $this->config->parser()->parse($token);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new TokenInvalidException('Could not decode token: '.$e->getMessage(), $e->getCode(), $e);
         }
 
@@ -166,7 +163,7 @@ class Lcobucci extends Provider implements JWT
         }
 
         return (new Collection($jwt->claims()->all()))->map(function ($claim) {
-            if (is_a($claim, DateTimeImmutable::class)) {
+            if (is_a($claim, \DateTimeImmutable::class)) {
                 return $claim->getTimestamp();
             }
             if (is_object($claim) && method_exists($claim, 'getValue')) {
@@ -181,7 +178,6 @@ class Lcobucci extends Provider implements JWT
      * Adds a claim to the {@see $config}.
      *
      * @param string $key
-     * @param mixed  $value
      */
     protected function addClaim($key, $value)
     {
@@ -194,13 +190,13 @@ class Lcobucci extends Provider implements JWT
                 $this->builder->identifiedBy($value);
                 break;
             case RegisteredClaims::EXPIRATION_TIME:
-                $this->builder->expiresAt(DateTimeImmutable::createFromFormat('U', $value));
+                $this->builder->expiresAt(\DateTimeImmutable::createFromFormat('U', $value));
                 break;
             case RegisteredClaims::NOT_BEFORE:
-                $this->builder->canOnlyBeUsedAfter(DateTimeImmutable::createFromFormat('U', $value));
+                $this->builder->canOnlyBeUsedAfter(\DateTimeImmutable::createFromFormat('U', $value));
                 break;
             case RegisteredClaims::ISSUED_AT:
-                $this->builder->issuedAt(DateTimeImmutable::createFromFormat('U', $value));
+                $this->builder->issuedAt(\DateTimeImmutable::createFromFormat('U', $value));
                 break;
             case RegisteredClaims::ISSUER:
                 $this->builder->issuedBy($value);
@@ -238,12 +234,9 @@ class Lcobucci extends Provider implements JWT
         return new $signer();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function isAsymmetric()
     {
-        $reflect = new ReflectionClass($this->signer);
+        $reflect = new \ReflectionClass($this->signer);
 
         return $reflect->isSubclassOf(Rsa::class) || $reflect->isSubclassOf(Ecdsa::class);
     }

--- a/src/Providers/JWT/Namshi.php
+++ b/src/Providers/JWT/Namshi.php
@@ -12,15 +12,11 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Providers\JWT;
 
-use Exception;
-use InvalidArgumentException;
 use Namshi\JOSE\JWS;
 use Namshi\JOSE\Signer\OpenSSL\PublicKey;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\JWT;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
-use ReflectionClass;
-use ReflectionException;
 
 class Namshi extends Provider implements JWT
 {
@@ -59,7 +55,7 @@ class Namshi extends Provider implements JWT
             $this->jws->setPayload($payload)->sign($this->getSigningKey(), $this->getPassphrase());
 
             return (string) $this->jws->getTokenString();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new JWTException('Could not create token: '.$e->getMessage(), $e->getCode(), $e);
         }
     }
@@ -78,7 +74,7 @@ class Namshi extends Provider implements JWT
         try {
             // Let's never allow insecure tokens
             $jws = $this->jws->load($token, false);
-        } catch (InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             throw new TokenInvalidException('Could not decode token: '.$e->getMessage(), $e->getCode(), $e);
         }
 
@@ -89,14 +85,11 @@ class Namshi extends Provider implements JWT
         return (array) $jws->getPayload();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function isAsymmetric()
     {
         try {
-            return (new ReflectionClass(sprintf('Namshi\\JOSE\\Signer\\OpenSSL\\%s', $this->getAlgo())))->isSubclassOf(PublicKey::class);
-        } catch (ReflectionException $e) {
+            return (new \ReflectionClass(sprintf('Namshi\\JOSE\\Signer\\OpenSSL\\%s', $this->getAlgo())))->isSubclassOf(PublicKey::class);
+        } catch (\ReflectionException $e) {
             throw new JWTException('The given algorithm could not be found', $e->getCode(), $e);
         }
     }

--- a/src/Providers/LaravelServiceProvider.php
+++ b/src/Providers/LaravelServiceProvider.php
@@ -23,9 +23,6 @@ use PHPOpenSourceSaver\JWTAuth\Http\Parser\RouteParams;
 
 class LaravelServiceProvider extends AbstractServiceProvider
 {
-    /**
-     * {@inheritdoc}
-     */
     public function boot()
     {
         $path = realpath(__DIR__.'/../../config/config.php');
@@ -55,9 +52,6 @@ class LaravelServiceProvider extends AbstractServiceProvider
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function registerStorageProvider()
     {
         $this->app->singleton('tymon.jwt.provider.storage', function ($app) {

--- a/src/Providers/LumenServiceProvider.php
+++ b/src/Providers/LumenServiceProvider.php
@@ -16,9 +16,6 @@ use PHPOpenSourceSaver\JWTAuth\Http\Parser\LumenRouteParams;
 
 class LumenServiceProvider extends AbstractServiceProvider
 {
-    /**
-     * {@inheritdoc}
-     */
     public function boot()
     {
         $this->app->configure('jwt');

--- a/src/Providers/Storage/Illuminate.php
+++ b/src/Providers/Storage/Illuminate.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Providers\Storage;
 
-use BadMethodCallException;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Storage;
 use Psr\SimpleCache\CacheInterface as PsrCacheInterface;
@@ -22,7 +21,7 @@ class Illuminate implements Storage
     /**
      * The cache repository contract.
      *
-     * @var \Illuminate\Contracts\Cache\Repository
+     * @var CacheContract
      */
     protected $cache;
 
@@ -57,7 +56,6 @@ class Illuminate implements Storage
      * Add a new item into storage.
      *
      * @param string $key
-     * @param mixed  $value
      * @param int    $minutes
      *
      * @return void
@@ -79,7 +77,6 @@ class Illuminate implements Storage
      * Add a new item into storage forever.
      *
      * @param string $key
-     * @param mixed  $value
      *
      * @return void
      */
@@ -92,8 +89,6 @@ class Illuminate implements Storage
      * Get an item from storage.
      *
      * @param string $key
-     *
-     * @return mixed
      */
     public function get($key)
     {
@@ -125,7 +120,7 @@ class Illuminate implements Storage
     /**
      * Return the cache instance with tags attached.
      *
-     * @return \Illuminate\Contracts\Cache\Repository
+     * @return CacheContract
      */
     protected function cache()
     {
@@ -164,7 +159,7 @@ class Illuminate implements Storage
                 // Attempt the repository tags command, which throws exceptions when unsupported
                 $this->cache->tags($this->tag);
                 $this->supportsTags = true;
-            } catch (BadMethodCallException $ex) {
+            } catch (\BadMethodCallException $ex) {
                 $this->supportsTags = false;
             }
         } else {

--- a/src/Validators/PayloadValidator.php
+++ b/src/Validators/PayloadValidator.php
@@ -58,7 +58,7 @@ class PayloadValidator extends Validator
      *
      * @return void
      *
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
+     * @throws TokenInvalidException
      */
     protected function validateStructure(Collection $claims)
     {
@@ -72,7 +72,7 @@ class PayloadValidator extends Validator
      *
      * @return Collection
      *
-     * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException
+     * @throws TokenInvalidException
      * @throws \PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException
      */
     protected function validatePayload(Collection $claims)

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -13,7 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Carbon\Carbon;
-use Mockery;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 abstract class AbstractTestCase extends TestCase
@@ -34,7 +33,7 @@ abstract class AbstractTestCase extends TestCase
     public function tearDown(): void
     {
         Carbon::setTestNow();
-        Mockery::close();
+        \Mockery::close();
 
         parent::tearDown();
     }

--- a/tests/BlacklistTest.php
+++ b/tests/BlacklistTest.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
-use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
@@ -38,9 +37,9 @@ class BlacklistTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->storage = Mockery::mock(Storage::class);
+        $this->storage = \Mockery::mock(Storage::class);
         $this->blacklist = new Blacklist($this->storage);
-        $this->validator = Mockery::mock(PayloadValidator::class);
+        $this->validator = \Mockery::mock(PayloadValidator::class);
     }
 
     /** @test */
@@ -193,9 +192,8 @@ class BlacklistTest extends AbstractTestCase
 
     /**
      * @test
-     * @dataProvider blacklist_provider
      *
-     * @param mixed $result
+     * @dataProvider blacklist_provider
      */
     public function itShouldCheckWhetherATokenHasNotBeenBlacklisted($result)
     {

--- a/tests/Claims/DatetimeClaimTest.php
+++ b/tests/Claims/DatetimeClaimTest.php
@@ -13,11 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test\Claims;
 
 use Carbon\Carbon;
-use DateInterval;
-use DateTime;
-use DateTimeImmutable;
-use DateTimeInterface;
-use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Expiration;
@@ -44,7 +39,7 @@ class DatetimeClaimTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->validator = Mockery::mock(PayloadValidator::class);
+        $this->validator = \Mockery::mock(PayloadValidator::class);
         $this->validator->shouldReceive('setRefreshFlow->check');
 
         $this->claimsTimestamp = [
@@ -66,8 +61,8 @@ class DatetimeClaimTest extends AbstractTestCase
         $testCarbonCopy = clone $testCarbon;
 
         $this->assertInstanceOf(Carbon::class, $testCarbon);
-        $this->assertInstanceOf(Datetime::class, $testCarbon);
-        $this->assertInstanceOf(DatetimeInterface::class, $testCarbon);
+        $this->assertInstanceOf(\DateTime::class, $testCarbon);
+        $this->assertInstanceOf(\DateTimeInterface::class, $testCarbon);
 
         $claimsDatetime = [
             'sub' => new Subject(1),
@@ -87,11 +82,11 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test */
     public function itShouldHandleDatetimeClaims()
     {
-        $testDateTime = DateTime::createFromFormat('U', $this->testNowTimestamp);
+        $testDateTime = \DateTime::createFromFormat('U', $this->testNowTimestamp);
         $testDateTimeCopy = clone $testDateTime;
 
-        $this->assertInstanceOf(DateTime::class, $testDateTime);
-        $this->assertInstanceOf(DatetimeInterface::class, $testDateTime);
+        $this->assertInstanceOf(\DateTime::class, $testDateTime);
+        $this->assertInstanceOf(\DateTimeInterface::class, $testDateTime);
 
         $claimsDatetime = [
             'sub' => new Subject(1),
@@ -111,10 +106,10 @@ class DatetimeClaimTest extends AbstractTestCase
     /** @test */
     public function itShouldHandleDatetimeImmutableClaims()
     {
-        $testDateTimeImmutable = DateTimeImmutable::createFromFormat('U', (string) $this->testNowTimestamp);
+        $testDateTimeImmutable = \DateTimeImmutable::createFromFormat('U', (string) $this->testNowTimestamp);
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $testDateTimeImmutable);
-        $this->assertInstanceOf(DatetimeInterface::class, $testDateTimeImmutable);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $testDateTimeImmutable);
+        $this->assertInstanceOf(\DateTimeInterface::class, $testDateTimeImmutable);
 
         $claimsDatetime = [
             'sub' => new Subject(1),
@@ -136,9 +131,9 @@ class DatetimeClaimTest extends AbstractTestCase
      */
     public function itShouldHandleDatetintervalClaims()
     {
-        $testDateInterval = new DateInterval('PT1H');
+        $testDateInterval = new \DateInterval('PT1H');
 
-        $this->assertInstanceOf(DateInterval::class, $testDateInterval);
+        $this->assertInstanceOf(\DateInterval::class, $testDateInterval);
 
         $claimsDateInterval = [
             'sub' => new Subject(1),

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
-use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
 use PHPOpenSourceSaver\JWTAuth\Claims\Custom;
@@ -40,8 +39,8 @@ class FactoryTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->claimFactory = Mockery::mock(ClaimFactory::class);
-        $this->validator = Mockery::mock(PayloadValidator::class);
+        $this->claimFactory = \Mockery::mock(ClaimFactory::class);
+        $this->validator = \Mockery::mock(PayloadValidator::class);
         $this->factory = new Factory($this->claimFactory, $this->validator);
     }
 

--- a/tests/Fixtures/Foo.php
+++ b/tests/Fixtures/Foo.php
@@ -16,8 +16,5 @@ use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
 
 class Foo extends Claim
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $name = 'foo';
 }

--- a/tests/Http/ParserTest.php
+++ b/tests/Http/ParserTest.php
@@ -16,7 +16,6 @@ use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Crypt;
-use Mockery;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Http\Parser as ParserContract;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 use PHPOpenSourceSaver\JWTAuth\Http\Parser\AuthHeaders;
@@ -132,6 +131,7 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @dataProvider whitespaceProvider
      */
     public function itShouldHandleExcessWhitespaceFromTheAuthorizationHeader($whitespace)
@@ -360,7 +360,7 @@ class ParserTest extends AbstractTestCase
 
     protected function getRouteMock($expectedParameterValue = null, $expectedParameterName = 'token')
     {
-        return Mockery::mock(Route::class)
+        return \Mockery::mock(Route::class)
             ->shouldReceive('parameter')
             ->with($expectedParameterName)
             ->andReturn($expectedParameterValue)
@@ -468,7 +468,7 @@ class ParserTest extends AbstractTestCase
             new RouteParams(),
         ];
 
-        $parser = new Parser(Mockery::mock(Request::class));
+        $parser = new Parser(\Mockery::mock(Request::class));
         $parser->setChain($chain);
 
         $this->assertSame($parser->getChain(), $chain);
@@ -485,7 +485,7 @@ class ParserTest extends AbstractTestCase
         ];
 
         /* @var Request $request */
-        $request = Mockery::mock(Request::class);
+        $request = \Mockery::mock(Request::class);
 
         $parser = new Parser($request);
         $parser->setChainOrder($chain);
@@ -505,7 +505,7 @@ class ParserTest extends AbstractTestCase
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
 
-        $customParser = Mockery::mock(ParserContract::class);
+        $customParser = \Mockery::mock(ParserContract::class);
         $customParser->shouldReceive('parse')->with($request)->andReturn('foobar');
 
         $parser = new Parser($request);
@@ -520,10 +520,10 @@ class ParserTest extends AbstractTestCase
     {
         $request = Request::create('foo', 'GET', ['foo' => 'bar']);
 
-        $customParser1 = Mockery::mock(ParserContract::class);
+        $customParser1 = \Mockery::mock(ParserContract::class);
         $customParser1->shouldReceive('parse')->with($request)->andReturn(false);
 
-        $customParser2 = Mockery::mock(ParserContract::class);
+        $customParser2 = \Mockery::mock(ParserContract::class);
         $customParser2->shouldReceive('parse')->with($request)->andReturn('foobar');
 
         $parser = new Parser($request);

--- a/tests/JWTAuthTest.php
+++ b/tests/JWTAuthTest.php
@@ -13,7 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Illuminate\Http\Request;
-use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Contracts\Providers\Auth;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
@@ -25,7 +24,6 @@ use PHPOpenSourceSaver\JWTAuth\Manager;
 use PHPOpenSourceSaver\JWTAuth\Payload;
 use PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub;
 use PHPOpenSourceSaver\JWTAuth\Token;
-use stdClass;
 
 class JWTAuthTest extends AbstractTestCase
 {
@@ -39,17 +37,17 @@ class JWTAuthTest extends AbstractTestCase
 
     public function setUp(): void
     {
-        $this->manager = Mockery::mock(Manager::class);
-        $this->auth = Mockery::mock(Auth::class);
-        $this->parser = Mockery::mock(Parser::class);
+        $this->manager = \Mockery::mock(Manager::class);
+        $this->auth = \Mockery::mock(Auth::class);
+        $this->parser = \Mockery::mock(Parser::class);
         $this->jwtAuth = new JWTAuth($this->manager, $this->auth, $this->parser);
     }
 
     /** @test */
     public function itShouldReturnATokenWhenPassingAUser()
     {
-        $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
+        $payloadFactory = \Mockery::mock(Factory::class);
+        $payloadFactory->shouldReceive('make')->andReturn(\Mockery::mock(Payload::class));
 
         $this->manager
             ->shouldReceive('getPayloadFactory->customClaims')
@@ -67,8 +65,8 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldPassProviderCheckIfHashMatches()
     {
-        $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
+        $payloadFactory = \Mockery::mock(Factory::class);
+        $payloadFactory->shouldReceive('make')->andReturn(\Mockery::mock(Payload::class));
         $payloadFactory->shouldReceive('get')
             ->with('prv')
             ->andReturn(sha1('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub'));
@@ -81,8 +79,8 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldPassProviderCheckIfHashMatchesWhenProviderIsNull()
     {
-        $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
+        $payloadFactory = \Mockery::mock(Factory::class);
+        $payloadFactory->shouldReceive('make')->andReturn(\Mockery::mock(Payload::class));
         $payloadFactory->shouldReceive('get')
             ->with('prv')
             ->andReturnNull();
@@ -95,8 +93,8 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldNotPassProviderCheckIfHashNotMatch()
     {
-        $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
+        $payloadFactory = \Mockery::mock(Factory::class);
+        $payloadFactory->shouldReceive('make')->andReturn(\Mockery::mock(Payload::class));
         $payloadFactory->shouldReceive('get')
             ->with('prv')
             ->andReturn(sha1('PHPOpenSourceSaver\JWTAuth\Test\Stubs\UserStub1'));
@@ -109,8 +107,8 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldReturnATokenWhenPassingValidCredentialsToAttemptMethod()
     {
-        $payloadFactory = Mockery::mock(Factory::class);
-        $payloadFactory->shouldReceive('make')->andReturn(Mockery::mock(Payload::class));
+        $payloadFactory = \Mockery::mock(Factory::class);
+        $payloadFactory->shouldReceive('make')->andReturn(\Mockery::mock(Payload::class));
 
         $this->manager
             ->shouldReceive('getPayloadFactory->customClaims')
@@ -152,7 +150,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldReturnTheOwningUserFromATokenContainingAnExistingUser()
     {
-        $payload = Mockery::mock(Payload::class);
+        $payload = \Mockery::mock(Payload::class);
         $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payload);
@@ -168,7 +166,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldReturnFalseWhenPassingATokenNotContainingAnExistingUser()
     {
-        $payload = Mockery::mock(Payload::class);
+        $payload = \Mockery::mock(Payload::class);
         $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payload);
@@ -184,7 +182,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldRefreshAToken()
     {
-        $newToken = Mockery::mock(Token::class);
+        $newToken = \Mockery::mock(Token::class);
         $newToken->shouldReceive('get')->once()->andReturn('baz.bar.foo');
 
         $this->manager->shouldReceive('customClaims->refresh')->once()->andReturn($newToken);
@@ -242,7 +240,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldReturnTrueIfTheTokenIsValid()
     {
-        $payload = Mockery::mock(Payload::class);
+        $payload = \Mockery::mock(Payload::class);
 
         $this->parser->shouldReceive('parseToken')->andReturn('foo.bar.baz');
         $this->manager->shouldReceive('decode')->once()->andReturn($payload);
@@ -272,11 +270,11 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldMagicallyCallTheManager()
     {
-        $this->manager->shouldReceive('getBlacklist')->andReturn(new stdClass());
+        $this->manager->shouldReceive('getBlacklist')->andReturn(new \stdClass());
 
         $blacklist = $this->jwtAuth->manager()->getBlacklist();
 
-        $this->assertInstanceOf(stdClass::class, $blacklist);
+        $this->assertInstanceOf(\stdClass::class, $blacklist);
     }
 
     /** @test */
@@ -321,7 +319,7 @@ class JWTAuthTest extends AbstractTestCase
     /** @test */
     public function itShouldGetAClaimValue()
     {
-        $payload = Mockery::mock(Payload::class);
+        $payload = \Mockery::mock(Payload::class);
         $payload->shouldReceive('get')->once()->with('sub')->andReturn(1);
 
         $this->manager->shouldReceive('decode')->once()->andReturn($payload);

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -20,7 +20,6 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
-use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\UserNotDefinedException;
@@ -44,9 +43,9 @@ class JWTGuardTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->jwt = Mockery::mock(JWT::class);
-        $this->provider = Mockery::mock(EloquentUserProvider::class);
-        $this->eventDispatcher = Mockery::mock(Dispatcher::class);
+        $this->jwt = \Mockery::mock(JWT::class);
+        $this->provider = \Mockery::mock(EloquentUserProvider::class);
+        $this->eventDispatcher = \Mockery::mock(Dispatcher::class);
         $this->guard = new JWTGuard(
             $this->jwt,
             $this->provider,
@@ -64,7 +63,7 @@ class JWTGuardTest extends AbstractTestCase
     /** @test */
     public function itShouldGetTheAuthenticatedUserIfAValidTokenIsProvided()
     {
-        $payload = Mockery::mock(Payload::class);
+        $payload = \Mockery::mock(Payload::class);
         $payload->shouldReceive('offsetGet')->once()->with('sub')->andReturn(1);
 
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
@@ -96,7 +95,7 @@ class JWTGuardTest extends AbstractTestCase
     /** @test */
     public function itShouldGetTheAuthenticatedUserIfAValidTokenIsProvidedAndNotThrowAnException()
     {
-        $payload = Mockery::mock(Payload::class);
+        $payload = \Mockery::mock(Payload::class);
         $payload->shouldReceive('offsetGet')->once()->with('sub')->andReturn(1);
 
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
@@ -213,21 +212,21 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Attempting::class));
+            ->with(\Mockery::type(Attempting::class));
 
         if (class_exists('Illuminate\Auth\Events\Validated')) {
             $this->eventDispatcher->shouldReceive('dispatch')
                 ->once()
-                ->with(Mockery::type('Illuminate\Auth\Events\Validated'));
+                ->with(\Mockery::type('Illuminate\Auth\Events\Validated'));
         }
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Login::class));
+            ->with(\Mockery::type(Login::class));
 
         $token = $this->guard->claims(['foo' => 'bar'])->attempt($credentials);
 
@@ -253,21 +252,21 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->twice()
-            ->with(Mockery::type(Attempting::class));
+            ->with(\Mockery::type(Attempting::class));
 
         if (class_exists('Illuminate\Auth\Events\Validated')) {
             $this->eventDispatcher->shouldReceive('dispatch')
                 ->twice()
-                ->with(Mockery::type('Illuminate\Auth\Events\Validated'));
+                ->with(\Mockery::type('Illuminate\Auth\Events\Validated'));
         }
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Login::class));
+            ->with(\Mockery::type(Login::class));
 
         $this->assertTrue($this->guard->attempt($credentials, false)); // once
         $this->assertTrue($this->guard->validate($credentials)); // twice
@@ -291,19 +290,19 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Attempting::class));
+            ->with(\Mockery::type(Attempting::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Failed::class));
+            ->with(\Mockery::type(Failed::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Login::class));
+            ->with(\Mockery::type(Login::class));
 
         $this->assertFalse($this->guard->attempt($credentials));
     }
@@ -311,7 +310,7 @@ class JWTGuardTest extends AbstractTestCase
     /** @test */
     public function itShouldMagicallyCallTheJwtInstance()
     {
-        $this->jwt->shouldReceive('factory')->andReturn(Mockery::mock(Factory::class));
+        $this->jwt->shouldReceive('factory')->andReturn(\Mockery::mock(Factory::class));
         $this->assertInstanceOf(Factory::class, $this->guard->factory());
     }
 
@@ -325,11 +324,11 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Logout::class));
+            ->with(\Mockery::type(Logout::class));
 
         $this->guard->logout();
         $this->assertNull($this->guard->getUser());
@@ -385,11 +384,11 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Login::class));
+            ->with(\Mockery::type(Login::class));
 
         $this->assertSame('foo.bar.baz', $this->guard->tokenById(1));
     }
@@ -423,21 +422,21 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Attempting::class));
+            ->with(\Mockery::type(Attempting::class));
 
         if (class_exists('Illuminate\Auth\Events\Validated')) {
             $this->eventDispatcher->shouldReceive('dispatch')
                 ->once()
-                ->with(Mockery::type('Illuminate\Auth\Events\Validated'));
+                ->with(\Mockery::type('Illuminate\Auth\Events\Validated'));
         }
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->never()
-            ->with(Mockery::type(Login::class));
+            ->with(\Mockery::type(Login::class));
 
         $this->assertTrue($this->guard->once($credentials));
     }
@@ -460,11 +459,11 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Attempting::class));
+            ->with(\Mockery::type(Attempting::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Failed::class));
+            ->with(\Mockery::type(Failed::class));
 
         $this->assertFalse($this->guard->once($credentials));
     }
@@ -481,7 +480,7 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->twice()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->assertTrue($this->guard->onceUsingId(1)); // once
         $this->assertTrue($this->guard->byId(1)); // twice
@@ -516,11 +515,11 @@ class JWTGuardTest extends AbstractTestCase
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Authenticated::class));
+            ->with(\Mockery::type(Authenticated::class));
 
         $this->eventDispatcher->shouldReceive('dispatch')
             ->once()
-            ->with(Mockery::type(Login::class));
+            ->with(\Mockery::type(Login::class));
 
         $token = $this->guard->login($user);
 
@@ -532,7 +531,7 @@ class JWTGuardTest extends AbstractTestCase
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
         $this->jwt->shouldReceive('getToken')->once()->andReturn('foo.bar.baz');
-        $this->jwt->shouldReceive('getPayload')->once()->andReturn(Mockery::mock(Payload::class));
+        $this->jwt->shouldReceive('getPayload')->once()->andReturn(\Mockery::mock(Payload::class));
         $this->assertInstanceOf(Payload::class, $this->guard->payload());
     }
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
-use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
@@ -48,11 +47,11 @@ class ManagerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->jwt = Mockery::mock(JWT::class);
-        $this->blacklist = Mockery::mock(Blacklist::class);
-        $this->factory = Mockery::mock(Factory::class);
+        $this->jwt = \Mockery::mock(JWT::class);
+        $this->blacklist = \Mockery::mock(Blacklist::class);
+        $this->factory = \Mockery::mock(Factory::class);
         $this->manager = new Manager($this->jwt, $this->blacklist, $this->factory);
-        $this->validator = Mockery::mock(PayloadValidator::class);
+        $this->validator = \Mockery::mock(PayloadValidator::class);
     }
 
     /** @test

--- a/tests/Middleware/AbstractMiddlewareTest.php
+++ b/tests/Middleware/AbstractMiddlewareTest.php
@@ -13,7 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Illuminate\Http\Request;
-use Mockery;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\JWTAuth;
 use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
@@ -34,7 +33,7 @@ abstract class AbstractMiddlewareTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->auth = Mockery::mock(JWTAuth::class);
-        $this->request = Mockery::mock(Request::class);
+        $this->auth = \Mockery::mock(JWTAuth::class);
+        $this->request = \Mockery::mock(Request::class);
     }
 }

--- a/tests/Middleware/AuthenticateAndRenewTest.php
+++ b/tests/Middleware/AuthenticateAndRenewTest.php
@@ -13,7 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Illuminate\Http\Response;
-use Mockery;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 use PHPOpenSourceSaver\JWTAuth\Http\Middleware\Authenticate;
 use PHPOpenSourceSaver\JWTAuth\Http\Middleware\AuthenticateAndRenew;
@@ -38,7 +37,7 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
     /** @test */
     public function itShouldAuthenticateAUserAndReturnANewToken()
     {
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
         $this->auth->shouldReceive('parser')->andReturn($parser);
         $this->auth->parser()->shouldReceive('setRequest')->once()->with($this->request)->andReturn($this->auth->parser());
@@ -59,7 +58,7 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
     {
         $this->expectException(UnauthorizedHttpException::class);
 
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -74,7 +73,7 @@ class AuthenticateAndRenewTest extends AbstractMiddlewareTest
     {
         $this->expectException(UnauthorizedHttpException::class);
 
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
-use Mockery;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 use PHPOpenSourceSaver\JWTAuth\Http\Middleware\Authenticate;
 use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
@@ -36,7 +35,7 @@ class AuthenticateTest extends AbstractMiddlewareTest
     /** @test */
     public function itShouldAuthenticateAUser()
     {
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -53,7 +52,7 @@ class AuthenticateTest extends AbstractMiddlewareTest
     {
         $this->expectException(UnauthorizedHttpException::class);
 
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -68,7 +67,7 @@ class AuthenticateTest extends AbstractMiddlewareTest
     {
         $this->expectException(UnauthorizedHttpException::class);
 
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -85,7 +84,7 @@ class AuthenticateTest extends AbstractMiddlewareTest
     {
         $this->expectException(UnauthorizedHttpException::class);
 
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);

--- a/tests/Middleware/CheckTest.php
+++ b/tests/Middleware/CheckTest.php
@@ -12,7 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
-use Mockery;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 use PHPOpenSourceSaver\JWTAuth\Http\Middleware\Check;
 use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
@@ -35,7 +34,7 @@ class CheckTest extends AbstractMiddlewareTest
     /** @test */
     public function itShouldAuthenticateAUserIfATokenIsPresent()
     {
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -50,7 +49,7 @@ class CheckTest extends AbstractMiddlewareTest
     /** @test */
     public function itShouldUnsetTheExceptionIfATokenIsPresent()
     {
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -65,7 +64,7 @@ class CheckTest extends AbstractMiddlewareTest
     /** @test */
     public function itShouldDoNothingIfATokenIsNotPresent()
     {
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);

--- a/tests/Middleware/RefreshTokenTest.php
+++ b/tests/Middleware/RefreshTokenTest.php
@@ -13,7 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test\Middleware;
 
 use Illuminate\Http\Response;
-use Mockery;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 use PHPOpenSourceSaver\JWTAuth\Http\Middleware\RefreshToken;
 use PHPOpenSourceSaver\JWTAuth\Http\Parser\Parser;
@@ -36,7 +35,7 @@ class RefreshTokenTest extends AbstractMiddlewareTest
     /** @test */
     public function itShouldRefreshAToken()
     {
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -56,7 +55,7 @@ class RefreshTokenTest extends AbstractMiddlewareTest
     {
         $this->expectException(UnauthorizedHttpException::class);
 
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(false);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);
@@ -71,7 +70,7 @@ class RefreshTokenTest extends AbstractMiddlewareTest
     {
         $this->expectException(UnauthorizedHttpException::class);
 
-        $parser = Mockery::mock(Parser::class);
+        $parser = \Mockery::mock(Parser::class);
         $parser->shouldReceive('hasToken')->once()->andReturn(true);
 
         $this->auth->shouldReceive('parser')->andReturn($parser);

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -12,8 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
-use BadMethodCallException;
-use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Claims\Audience;
 use PHPOpenSourceSaver\JWTAuth\Claims\Claim;
@@ -67,7 +65,7 @@ class PayloadTest extends AbstractTestCase
 
         $collection = Collection::make($claims);
 
-        $this->validator = Mockery::mock(PayloadValidator::class);
+        $this->validator = \Mockery::mock(PayloadValidator::class);
         $this->validator->shouldReceive('setRefreshFlow->check')->andReturn($collection);
 
         return new Payload($collection, $this->validator);
@@ -169,7 +167,7 @@ class PayloadTest extends AbstractTestCase
     /** @test */
     public function itShouldThrowAnExceptionWhenMagicallyGettingAPropertyThatDoesNotExist()
     {
-        $this->expectException(BadMethodCallException::class);
+        $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('The claim [Foo] does not exist on the payload');
 
         $this->payload->getFoo();

--- a/tests/Providers/Auth/IlluminateTest.php
+++ b/tests/Providers/Auth/IlluminateTest.php
@@ -13,7 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\Auth;
 
 use Illuminate\Contracts\Auth\Guard;
-use Mockery;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Providers\Auth\Illuminate as Auth;
 use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
@@ -34,7 +33,7 @@ class IlluminateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->authManager = Mockery::mock(Guard::class);
+        $this->authManager = \Mockery::mock(Guard::class);
         $this->auth = new Auth($this->authManager);
     }
 

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -12,8 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\JWT;
 
-use Exception;
-use InvalidArgumentException;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer;
@@ -22,7 +20,6 @@ use Lcobucci\JWT\Signer\Rsa\Sha256 as RS256;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Token\DataSet;
 use Lcobucci\JWT\Validation\Constraint;
-use Mockery;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
@@ -57,8 +54,8 @@ class LcobucciTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->builder = Mockery::mock(Builder::class);
-        $this->parser = Mockery::mock(Parser::class);
+        $this->builder = \Mockery::mock(Builder::class);
+        $this->parser = \Mockery::mock(Parser::class);
     }
 
     /** @test */
@@ -100,7 +97,7 @@ class LcobucciTest extends AbstractTestCase
             ->shouldReceive('getToken')
             ->once()
             ->with(\Mockery::type(Signer::class), \Mockery::type(Key::class))
-            ->andThrow(new Exception());
+            ->andThrow(new \Exception());
 
         $this->getProvider('secret', 'HS256')->encode($payload);
     }
@@ -110,13 +107,13 @@ class LcobucciTest extends AbstractTestCase
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
-        $token = Mockery::mock(Token::class);
-        $dataSet = Mockery::mock(new DataSet($payload, 'payload'));
+        $token = \Mockery::mock(Token::class);
+        $dataSet = \Mockery::mock(new DataSet($payload, 'payload'));
 
         $provider = $this->getProvider('secret', 'HS256');
 
         $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andReturn($token);
-        $this->validator->shouldReceive('validate')->once()->with($token, Mockery::any())->andReturnTrue();
+        $this->validator->shouldReceive('validate')->once()->with($token, \Mockery::any())->andReturnTrue();
         $token->shouldReceive('claims')->once()->andReturn($dataSet);
         $dataSet->shouldReceive('all')->once()->andReturn($payload);
 
@@ -126,8 +123,8 @@ class LcobucciTest extends AbstractTestCase
     /** @test */
     public function itShouldThrowATokenInvalidExceptionWhenTheTokenCouldNotBeDecodedDueToABadSignature()
     {
-        $token = Mockery::mock(Token::class);
-        $dataSet = Mockery::mock(new DataSet(['pay', 'load'], 'payload'));
+        $token = \Mockery::mock(Token::class);
+        $dataSet = \Mockery::mock(new DataSet(['pay', 'load'], 'payload'));
 
         $provider = $this->getProvider('secret', 'HS256');
 
@@ -135,7 +132,7 @@ class LcobucciTest extends AbstractTestCase
         $this->expectExceptionMessage('Token Signature could not be verified.');
 
         $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andReturn($token);
-        $this->validator->shouldReceive('validate')->once()->with($token, Mockery::any())->andReturnFalse();
+        $this->validator->shouldReceive('validate')->once()->with($token, \Mockery::any())->andReturnFalse();
         $token->shouldReceive('claims')->never();
         $dataSet->shouldReceive('all')->never();
 
@@ -148,7 +145,7 @@ class LcobucciTest extends AbstractTestCase
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Could not decode token:');
 
-        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andThrow(new InvalidArgumentException());
+        $this->parser->shouldReceive('parse')->once()->with('foo.bar.baz')->andThrow(new \InvalidArgumentException());
         $this->parser->shouldReceive('verify')->never();
         $this->parser->shouldReceive('getClaims')->never();
 
@@ -178,7 +175,7 @@ class LcobucciTest extends AbstractTestCase
         $this->builder
             ->shouldReceive('getToken')
             ->once()
-            ->with(Mockery::type(RS256::class), Mockery::type(Key::class))
+            ->with(\Mockery::type(RS256::class), \Mockery::type(Key::class))
             ->andReturn(new Token\Plain(new DataSet([], 'header'), $dataSet, new Token\Signature('', 'signature')));
 
         $token = $provider->encode($payload);
@@ -238,8 +235,8 @@ class LcobucciTest extends AbstractTestCase
     {
         $provider = new Lcobucci($secret, $algo, $keys);
 
-        $this->validator = Mockery::mock(\Lcobucci\JWT\Validator::class);
-        $this->config = Mockery::mock($provider->getConfig());
+        $this->validator = \Mockery::mock(\Lcobucci\JWT\Validator::class);
+        $this->config = \Mockery::mock($provider->getConfig());
 
         $provider = new Lcobucci($secret, $algo, $keys, $this->config);
 
@@ -247,7 +244,7 @@ class LcobucciTest extends AbstractTestCase
         $this->config->shouldReceive('parser')->andReturn($this->parser);
         $this->config->shouldReceive('validator')->andReturn($this->validator);
 
-        $constraint = Mockery::mock(Constraint::class);
+        $constraint = \Mockery::mock(Constraint::class);
         $constraint->shouldReceive('assert')->andReturn();
         $this->config->shouldReceive('validationConstraints')->andReturn([$constraint]);
 

--- a/tests/Providers/JWT/NamshiTest.php
+++ b/tests/Providers/JWT/NamshiTest.php
@@ -12,9 +12,6 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\JWT;
 
-use Exception;
-use InvalidArgumentException;
-use Mockery;
 use Mockery\MockInterface;
 use Namshi\JOSE\JWS;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
@@ -38,7 +35,7 @@ class NamshiTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->jws = Mockery::mock(JWS::class);
+        $this->jws = \Mockery::mock(JWS::class);
     }
 
     /** @test */
@@ -46,8 +43,8 @@ class NamshiTest extends AbstractTestCase
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
-        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(Mockery::self());
-        $this->jws->shouldReceive('sign')->once()->with('secret', null)->andReturn(Mockery::self());
+        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(\Mockery::self());
+        $this->jws->shouldReceive('sign')->once()->with('secret', null)->andReturn(\Mockery::self());
         $this->jws->shouldReceive('getTokenString')->once()->andReturn('foo.bar.baz');
 
         $token = $this->getProvider('secret', 'HS256')->encode($payload);
@@ -68,8 +65,8 @@ class NamshiTest extends AbstractTestCase
 
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
-        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(Mockery::self());
-        $this->jws->shouldReceive('sign')->andThrow(new Exception());
+        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(\Mockery::self());
+        $this->jws->shouldReceive('sign')->andThrow(new \Exception());
 
         $this->getProvider('secret', 'HS256')->encode($payload);
     }
@@ -79,7 +76,7 @@ class NamshiTest extends AbstractTestCase
     {
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
-        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andReturn(Mockery::self());
+        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andReturn(\Mockery::self());
         $this->jws->shouldReceive('verify')->once()->with('secret', 'HS256')->andReturn(true);
         $this->jws->shouldReceive('getPayload')->andReturn($payload);
 
@@ -92,7 +89,7 @@ class NamshiTest extends AbstractTestCase
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Token Signature could not be verified.');
 
-        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andReturn(Mockery::self());
+        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andReturn(\Mockery::self());
         $this->jws->shouldReceive('verify')->once()->with('secret', 'HS256')->andReturn(false);
         $this->jws->shouldReceive('getPayload')->never();
 
@@ -105,7 +102,7 @@ class NamshiTest extends AbstractTestCase
         $this->expectException(TokenInvalidException::class);
         $this->expectExceptionMessage('Could not decode token:');
 
-        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andThrow(new InvalidArgumentException());
+        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andThrow(new \InvalidArgumentException());
         $this->jws->shouldReceive('verify')->never();
         $this->jws->shouldReceive('getPayload')->never();
 
@@ -123,8 +120,8 @@ class NamshiTest extends AbstractTestCase
 
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
-        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(Mockery::self());
-        $this->jws->shouldReceive('sign')->once()->with($this->getDummyPrivateKey(), null)->andReturn(Mockery::self());
+        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(\Mockery::self());
+        $this->jws->shouldReceive('sign')->once()->with($this->getDummyPrivateKey(), null)->andReturn(\Mockery::self());
         $this->jws->shouldReceive('getTokenString')->once()->andReturn('foo.bar.baz');
 
         $token = $provider->encode($payload);
@@ -153,8 +150,8 @@ class NamshiTest extends AbstractTestCase
 
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
-        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(Mockery::self());
-        $this->jws->shouldReceive('sign')->once()->with($this->getDummyPrivateKey(), null)->andReturn(Mockery::self());
+        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(\Mockery::self());
+        $this->jws->shouldReceive('sign')->once()->with($this->getDummyPrivateKey(), null)->andReturn(\Mockery::self());
         $this->jws->shouldReceive('getTokenString')->once()->andReturn('foo.bar.baz');
 
         $token = $provider->encode($payload);
@@ -173,8 +170,8 @@ class NamshiTest extends AbstractTestCase
 
         $payload = ['sub' => 1, 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
 
-        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(Mockery::self());
-        $this->jws->shouldReceive('sign')->once()->with($this->getDummyPrivateKey(), null)->andReturn(Mockery::self());
+        $this->jws->shouldReceive('setPayload')->once()->with($payload)->andReturn(\Mockery::self());
+        $this->jws->shouldReceive('sign')->once()->with($this->getDummyPrivateKey(), null)->andReturn(\Mockery::self());
         $this->jws->shouldReceive('getTokenString')->once()->andReturn('foo.bar.baz');
 
         $token = $provider->encode($payload);
@@ -188,7 +185,7 @@ class NamshiTest extends AbstractTestCase
         $this->expectException(JWTException::class);
         $this->expectExceptionMessage('The given algorithm could not be found');
 
-        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andReturn(Mockery::self());
+        $this->jws->shouldReceive('load')->once()->with('foo.bar.baz', false)->andReturn(\Mockery::self());
         $this->jws->shouldReceive('verify')->with('secret', 'AlgorithmWrong')->andReturn(true);
 
         $this->getProvider('secret', 'AlgorithmWrong')->decode('foo.bar.baz');

--- a/tests/Providers/Storage/IlluminateTest.php
+++ b/tests/Providers/Storage/IlluminateTest.php
@@ -13,7 +13,6 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test\Providers\Storage;
 
 use Illuminate\Contracts\Cache\Repository;
-use Mockery;
 use Mockery\MockInterface;
 use PHPOpenSourceSaver\JWTAuth\Providers\Storage\Illuminate as Storage;
 use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
@@ -35,7 +34,7 @@ class IlluminateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->cache = Mockery::mock(Repository::class);
+        $this->cache = \Mockery::mock(Repository::class);
         $this->storage = new Storage($this->cache);
     }
 
@@ -100,7 +99,7 @@ class IlluminateTest extends AbstractTestCase
     {
         $this->storage = new TaggedStorage($this->cache);
 
-        $this->cache->shouldReceive('tags')->with('tymon.jwt')->once()->andReturn(Mockery::self());
+        $this->cache->shouldReceive('tags')->with('tymon.jwt')->once()->andReturn(\Mockery::self());
     }
 
     /** @test */

--- a/tests/Stubs/JWTProviderStub.php
+++ b/tests/Stubs/JWTProviderStub.php
@@ -16,9 +16,6 @@ use PHPOpenSourceSaver\JWTAuth\Providers\JWT\Provider;
 
 class JWTProviderStub extends Provider
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function isAsymmetric()
     {
         return false;

--- a/tests/Validators/TokenValidatorTest.php
+++ b/tests/Validators/TokenValidatorTest.php
@@ -38,6 +38,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderMalformedTokens
      *
      * @param string $token
@@ -49,6 +50,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderMalformedTokens
      */
     public function itShouldThrowAnExceptionWhenProvidingAMalformedToken($token)
@@ -61,6 +63,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
      */
     public function itShouldReturnFalseWhenProvidingATokenWithWrongSegmentsNumber($token)
@@ -70,6 +73,7 @@ class TokenValidatorTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @dataProvider \PHPOpenSourceSaver\JWTAuth\Test\Validators\TokenValidatorTest::dataProviderTokensWithWrongSegmentsNumber
      */
     public function itShouldThrowAnExceptionWhenProvidingAMalformedTokenWithWrongSegmentsNumber($token)


### PR DESCRIPTION
## Summary
Some of the the referenced actions are already quite outdated and cause a lot of warnings emmited if you check the workflow runs:

- bump actions/cache
  Fixes:
  > `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`
- replace set-output with GITHUB_OUTPUT
  Fixes:
  > `The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- bump codecov/codecov-action
  Fixes
  > `The following actions uses node12 which is deprecated and will be forced to run on node16: codecov/codecov-action@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
  
  I checked the workflow and upload works, see https://github.com/PHP-Open-Source-Saver/jwt-auth/actions/runs/7986070882/job/21805731559?pr=232#step:11:50
- bump actions/checkout
  Fixes
  > `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/cache@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

### Notes
- About the **php-cs-fixer** commit: this is _unrelated_ to my changes, it simply wasn't run in a long time and php-cs-fixer evolved and therefore applies these changes.
- They are still warnings emmited, but they're of different nature:
  ![image](https://github.com/PHP-Open-Source-Saver/jwt-auth/assets/87493/1e2c0eb7-849d-4f83-9c87-214dce9d34e1)
