### PR TITLE
gha: don't run php-cs-fixer on main branch

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -2,6 +2,8 @@ name: Coding Standards
 
 on:
   push:
+    branches:
+      - '!main'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
I retrospect, I think the fix for #142 is pretty obvious: don't run php-cs-fixer on the `main` branch 😅

As pointed out in the issue discussion, that branch is protected so you can't just push to it without a proper token. But that's overkill and not needed.

I'd argue, it's even not wanted. php-cs-fixer is a great piece and it shall never produce errors but you never know: having fixes auto-commited on PRs, like on https://github.com/PHP-Open-Source-Saver/jwt-auth/pull/232 , is good enough