### PR TITLE
lcobucci/jwt: add array support for `aud` claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can find and compare releases at the GitHub release page.
 
 ### Added
 - Different TTL configurations for each guard
+- lcobucci/jwt: add array support for `aud` claim
 
 ## [2.0.0] 2022-09-08
 - No changes to 2.0.0-RC1

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -202,7 +202,11 @@ class Lcobucci extends Provider implements JWT
                 $this->builder->issuedBy($value);
                 break;
             case RegisteredClaims::AUDIENCE:
-                $this->builder->permittedFor($value);
+                if (is_array($value)) {
+                    $this->builder->permittedFor(...$value);
+                } else {
+                    $this->builder->permittedFor($value);
+                }
                 break;
             case RegisteredClaims::SUBJECT:
                 $this->builder->relatedTo($value);

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -231,6 +231,48 @@ class LcobucciTest extends AbstractTestCase
         $this->assertSame('ES256', $provider->getConfig()->signer()->algorithmId());
     }
 
+    public function testEncodeAudienceClaimString(): void
+    {
+        $payload = [
+            'aud' => 'foo',
+        ];
+
+        $dataSet = new DataSet($payload, 'payload');
+
+        $this->builder->shouldReceive('permittedFor')->once()->andReturnSelf();  // aud
+        $this->builder
+            ->shouldReceive('getToken')
+            ->once()
+            ->with(\Mockery::type(Signer::class), \Mockery::type(Key::class))
+            ->andReturn(new Token\Plain(new DataSet([], 'header'), $dataSet, new Token\Signature('', 'signature')));
+
+        /** @var Token $token */
+        $token = $this->getProvider('secret', 'HS256')->encode($payload);
+
+        $this->assertSame('header.payload.signature', $token);
+    }
+
+    public function testEncodeAudienceClaimArray(): void
+    {
+        $payload = [
+            'aud' => ['foo', 'bar'],
+        ];
+
+        $dataSet = new DataSet($payload, 'payload');
+
+        $this->builder->shouldReceive('permittedFor')->once()->andReturnSelf();  // aud
+        $this->builder
+            ->shouldReceive('getToken')
+            ->once()
+            ->with(\Mockery::type(Signer::class), \Mockery::type(Key::class))
+            ->andReturn(new Token\Plain(new DataSet([], 'header'), $dataSet, new Token\Signature('', 'signature')));
+
+        /** @var Token $token */
+        $token = $this->getProvider('secret', 'HS256')->encode($payload);
+
+        $this->assertSame('header.payload.signature', $token);
+    }
+
     public function getProvider($secret, $algo, array $keys = [])
     {
         $provider = new Lcobucci($secret, $algo, $keys);


### PR DESCRIPTION
## Description
The underlying library already supports it (accepts multiples string args, see [1]).

[1] https://github.com/lcobucci/jwt/blob/4.3.x/src/Builder.php#L20

Fixes #225

## Checklist:
- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
