### PR TITLE
Add support for Carbon^3

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
         laravel: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
@@ -25,18 +25,26 @@ jobs:
             php: 8.1
           - laravel: 6.*
             php: 8.2
+          - laravel: 6.*
+            php: 8.3
           - laravel: 7.*
             php: 8.1
           - laravel: 7.*
             php: 8.2
+          - laravel: 7.*
+            php: 8.3
           - laravel: 8.*
             php: 8.2
             stability: prefer-lowest
+          - laravel: 8.*
+            php: 8.3
           - laravel: 9.*
             php: 7.4
           - laravel: 9.*
             php: 8.2
             stability: prefer-lowest
+          - laravel: 9.*
+            php: 8.3
           - laravel: 10.*
             php: 7.4
           - laravel: 10.*

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "illuminate/support": "^6|^7|^8.67|^9|^10|^11",
         "lcobucci/jwt": "^4.0",
         "namshi/jose": "^7.0",
-        "nesbot/carbon": "^1.0|^2.0"
+        "nesbot/carbon": "^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "illuminate/support": "^6|^7|^8.67|^9|^10|^11",
         "lcobucci/jwt": "^4.0",
         "namshi/jose": "^7.0",
-        "nesbot/carbon": "^2.0"
+        "nesbot/carbon": "^2.0|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -95,7 +95,7 @@ class Blacklist
         // get the latter of the two expiration dates and find
         // the number of minutes until the expiration date,
         // plus 1 minute to avoid overlap
-        return $exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInRealMinutes();
+        return round($exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInRealMinutes(null, true));
     }
 
     /**


### PR DESCRIPTION
## Summary
Laravel 11 support was recently added via https://github.com/PHP-Open-Source-Saver/jwt-auth/pull/233

Laravel 11 supports both carbon 2 & 3, see https://github.com/laravel/framework/blob/ae2f9413b5bd8637c363e6fafffda31c88e56c9e/composer.json#L39
> `"nesbot/carbon": "^2.72.2|^3.0",`

However, projects running Laravel 11 _and_ also requiring carbon:^3 (or have other dependencies requiring it), cannot install jwt-auth because we still only support carbon^2.

This PR fixes that, see also https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/230#issuecomment-2002016625

### Overview of changes
- Runs tests on 8.3 too
- Remove carbon^1
  There was no constellation possible which actually used it. Even Laravel 6 with `prefer-lowest` did install carbon^2, see any random run, e.g. https://github.com/PHP-Open-Source-Saver/jwt-auth/actions/runs/8252381702/job/22571741990#step:11:34
  > [PHP 7.4] [Laravel 6.* - prefer-lowest]
  > …
  > ` - Locking nesbot/carbon (2.31.0)`
- Add support for carbon^3
  Carbon 3 has some breaking changes and one of them affected the Method `diffInRealMinutes` we call from `\PHPOpenSourceSaver\JWTAuth\Blacklist::getMinutesUntilExpired`
  - the result was negative, i.e. `-2…`
  - the result was a float, i.e. had a decimal point: `.9…`
  
  The change using `round()` and adding a 2nd arg `true` keeps the code BC.
  Without the fix, tests in `\PHPOpenSourceSaver\JWTAuth\Test\BlacklistTest` would fail