### PR TITLE
Drop support for Laravel < 10

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.3
           coverage: none
 
       - name: Determine composer cache directory

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
           coverage: none
 
       - name: Get composer cache directory

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,78 +15,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3]
-        laravel: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         coverage: [none]
         exclude:
-          - laravel: 6.*
-            php: 8.1
-          - laravel: 6.*
-            php: 8.2
-          - laravel: 6.*
-            php: 8.3
-          - laravel: 7.*
-            php: 8.1
-          - laravel: 7.*
-            php: 8.2
-          - laravel: 7.*
-            php: 8.3
-          - laravel: 8.*
-            php: 8.2
-            stability: prefer-lowest
-          - laravel: 8.*
-            php: 8.3
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 9.*
-            php: 8.2
-            stability: prefer-lowest
-          - laravel: 9.*
-            php: 8.3
-          - laravel: 10.*
-            php: 7.4
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 11.*
-            php: 7.4
-          - laravel: 11.*
-            php: 8.0
           - laravel: 11.*
             php: 8.1
         include:
-          - laravel: 6.*
-            dotenv: ^3.3
-
-          - laravel: 7.*
-            dotenv: ^4.0
-
-          - laravel: 8.*
-            dotenv: ^5.2
-
-          - laravel: 9.*
-            dotenv: ^5.2
-
-          - laravel: 10.*
-            dotenv: ^5.4.1
-
-          - laravel: 11.*
-            dotenv: ^5.4.1
-
-          - php: 8.0
-            laravel: 9.*
-            stability: prefer-stable
-            os: ubuntu-latest
-            coverage: xdebug
-            dotenv: ^5.2
-
           - php: 8.1
             laravel: 10.*
             stability: prefer-stable
             os: ubuntu-latest
             coverage: xdebug
-            dotenv: ^5.4.1
 
     name: '[PHP ${{ matrix.php }}] [Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}] [${{ matrix.coverage }} coverage]'
 
@@ -122,7 +64,6 @@ jobs:
       - name: Set Minimum Laravel ${{ matrix.laravel }} Versions
         run: |
           composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-progress --no-update
-          composer require "vlucas/phpdotenv:${{ matrix.dotenv }}" --no-interaction --no-progress --no-update --dev
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ You can find and compare releases at the GitHub release page.
 ### Added
 - Support for Carbon 3 (and drop Carbon 1, but it was unused anyway)
 
+### Removed
+- Dropped support for Laravel < 10 and PHP < 8.1
+
 ## [2.2.0] 2024-03-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ You can find and compare releases at the GitHub release page.
 ## [Unreleased]
 
 ### Added
+- Support for Carbon 3 (and drop Carbon 1, but it was unused anyway)
+
+## [2.2.0] 2024-03-12
+
+### Added
 - Different TTL configurations for each guard
 - lcobucci/jwt: add array support for `aud` claim
 - Laravel 11 support

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This uses different namespace, then `tymondesigns/jwt-auth`, but overall, provid
 
 ### Notes
 
-Due to new features, added in our library, there are some incompatibilities. _This won't hurt you in most cases_, unless you have [implicitly disabled autodiscovery](https://laravel.com/docs/8.x/packages#opting-out-of-package-discovery) for original Tymon's package.
+Due to new features, added in our library, there are some incompatibilities. _This won't hurt you in most cases_, unless you have [implicitly disabled autodiscovery](https://laravel.com/docs/11.x/packages#opting-out-of-package-discovery) for original Tymon's package.
 
 Current compatability breaks:
 - [`JWTGuard`](src/JWTGuard.php) have new required constructor parameter [`$eventDispatcher`](src/Providers/AbstractServiceProvider.php#L97) 

--- a/composer.json
+++ b/composer.json
@@ -33,24 +33,24 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
-        "illuminate/auth": "^6|^7|^8.67|^9|^10|^11",
-        "illuminate/contracts": "^6|^7|^8.67|^9|^10|^11",
-        "illuminate/http": "^6|^7|^8.67|^9|^10|^11",
-        "illuminate/support": "^6|^7|^8.67|^9|^10|^11",
+        "illuminate/auth": "^10|^11",
+        "illuminate/contracts": "^10|^11",
+        "illuminate/http": "^10|^11",
+        "illuminate/support": "^10|^11",
         "lcobucci/jwt": "^4.0",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^2.0|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
-        "illuminate/console": "^6|^7|^8.67|^9|^10|^11",
-        "illuminate/routing": "^6|^7|^8.67|^9|^10|^11",
-        "orchestra/testbench": "^4.18|^5.8|^6.3|^7|^8|^9|9.x-dev",
+        "illuminate/console": "^10|^11",
+        "illuminate/routing": "^10|^11",
+        "orchestra/testbench": "^8|^9",
         "mockery/mockery": "^1.4.4",
         "phpstan/phpstan": "^1",
-        "phpunit/phpunit": "^8.5|^9.4|^10",
+        "phpunit/phpunit": "^9.4|^10",
         "vlucas/phpdotenv": "^5.2.0",
         "yoast/phpunit-polyfills": "^2.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
         "orchestra/testbench": "^8|^9",
         "mockery/mockery": "^1.4.4",
         "phpstan/phpstan": "^1",
-        "phpunit/phpunit": "^9.4|^10",
-        "yoast/phpunit-polyfills": "^2.0.0"
+        "phpunit/phpunit": "^9.4|^10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         "mockery/mockery": "^1.4.4",
         "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^9.4|^10",
-        "vlucas/phpdotenv": "^5.2.0",
         "yoast/phpunit-polyfills": "^2.0.0"
     },
     "autoload": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,6 +71,11 @@ parameters:
 			path: tests/Stubs/LaravelUserStub.php
 
 		-
+			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Test\\\\Stubs\\\\LaravelUserStub\\:\\:getAuthPasswordName\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Stubs/LaravelUserStub.php
+
+		-
 			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Test\\\\Stubs\\\\LaravelUserStub\\:\\:getRememberToken\\(\\) should return string but return statement is missing\\.$#"
 			count: 1
 			path: tests/Stubs/LaravelUserStub.php

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -13,7 +13,7 @@
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
 use Carbon\Carbon;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use PHPUnit\Framework\TestCase;
 
 abstract class AbstractTestCase extends TestCase
 {


### PR DESCRIPTION
## Description
Similar to https://github.com/PHP-Open-Source-Saver/jwt-auth/pull/229 but only concentrate o the part to drop support for unsupported software.

This also means we drop PHP < 8.1, as 8.1 is the minimum, see https://laravel.com/docs/11.x/releases#support-policy , as Laravel 9 is EOL since a month:
![image](https://github.com/PHP-Open-Source-Saver/jwt-auth/assets/87493/b889b44b-eef1-4d32-ae8c-40819dfcb225)


Also cleaned up a bit:
- Bump other PHP versions to their latest stable release (8.3) for GHA workflows.
- Removed phpdotenv, not needed 🤷🏼 
- Removed yoast/phpunit-polyfills, not needed 🤷🏼 

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
