### PR TITLE
fix addMinutes to Carbon 3

### DIFF
--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -199,7 +199,7 @@ class Factory
      */
     public function setTTL($ttl)
     {
-        $this->ttl = $ttl;
+        $this->ttl = $ttl ? (int) $ttl : $ttl;
 
         return $this;
     }


### PR DESCRIPTION
in Carbon 3, the return Utils::now()->addMinutes($this->ttl)->getTimestamp() line gives an error if it does not receive an integer.

This code corrects that, but it doesn't handle null values, I don't know why there is a null value.