### PR TITLE
Bump lcobucci jwt version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ You can find and compare releases at the GitHub release page.
 ## [Unreleased]
 
 ### Added
+- Support for lcobucci/jwt^5.0 (and dropped support for ^4.0)
+
+## [2.3.0] 2024-05-09
+
+### Added
 - Support for Carbon 3 (and drop Carbon 1, but it was unused anyway)
 
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "illuminate/contracts": "^10|^11",
         "illuminate/http": "^10|^11",
         "illuminate/support": "^10|^11",
-        "lcobucci/jwt": "^4.0",
+        "lcobucci/jwt": "^5.0",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^2.0|^3.0"
     },

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -231,10 +231,6 @@ class Lcobucci extends Provider implements JWT
 
         $signer = $this->signers[$this->algo];
 
-        if (is_subclass_of($signer, Ecdsa::class)) {
-            return $signer::create();
-        }
-
         return new $signer();
     }
 

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -132,7 +132,7 @@ class Lcobucci extends Provider implements JWT
 
         try {
             foreach ($payload as $key => $value) {
-                $this->addClaim($key, $value);
+                $this->builder = $this->addClaim($key, $value);
             }
 
             return $this->builder->getToken($this->config->signer(), $this->config->signingKey())->toString();
@@ -179,41 +179,22 @@ class Lcobucci extends Provider implements JWT
      *
      * @param string $key
      */
-    protected function addClaim($key, $value)
+    protected function addClaim($key, $value): Builder
     {
         if (!isset($this->builder)) {
             $this->builder = $this->config->builder();
         }
 
-        switch ($key) {
-            case RegisteredClaims::ID:
-                $this->builder->identifiedBy($value);
-                break;
-            case RegisteredClaims::EXPIRATION_TIME:
-                $this->builder->expiresAt(\DateTimeImmutable::createFromFormat('U', $value));
-                break;
-            case RegisteredClaims::NOT_BEFORE:
-                $this->builder->canOnlyBeUsedAfter(\DateTimeImmutable::createFromFormat('U', $value));
-                break;
-            case RegisteredClaims::ISSUED_AT:
-                $this->builder->issuedAt(\DateTimeImmutable::createFromFormat('U', $value));
-                break;
-            case RegisteredClaims::ISSUER:
-                $this->builder->issuedBy($value);
-                break;
-            case RegisteredClaims::AUDIENCE:
-                if (is_array($value)) {
-                    $this->builder->permittedFor(...$value);
-                } else {
-                    $this->builder->permittedFor($value);
-                }
-                break;
-            case RegisteredClaims::SUBJECT:
-                $this->builder->relatedTo($value);
-                break;
-            default:
-                $this->builder->withClaim($key, $value);
-        }
+        return match ($key) {
+            RegisteredClaims::ID => $this->builder->identifiedBy($value),
+            RegisteredClaims::EXPIRATION_TIME => $this->builder->expiresAt(\DateTimeImmutable::createFromFormat('U', $value)),
+            RegisteredClaims::NOT_BEFORE => $this->builder->canOnlyBeUsedAfter(\DateTimeImmutable::createFromFormat('U', $value)),
+            RegisteredClaims::ISSUED_AT => $this->builder->issuedAt(\DateTimeImmutable::createFromFormat('U', $value)),
+            RegisteredClaims::ISSUER => $this->builder->issuedBy($value),
+            RegisteredClaims::AUDIENCE => is_array($value) ? $this->builder->permittedFor(...$value) : $this->builder->permittedFor($value),
+            RegisteredClaims::SUBJECT => $this->builder->relatedTo($value),
+            default => $this->builder->withClaim($key, $value),
+        };
     }
 
     /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Alternative implementation of #229. Since [2.3.0](https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.3.0) dropped support for Laravel < 10, none of the Laravel related changes in #229 are needed.

Upgrade guide can be found [here](https://github.com/lcobucci/jwt/blob/5.4.x/docs/upgrading.md). The two notables are

1. Removal of `Lcobucci\JWT\Signer\Ecdsa::create()` done [here](https://github.com/lcobucci/jwt/pull/967). This was causing failures in a few tests. Simply not calling this method and using `new $signer()` like is done with other Signer types fixes this.

2. `Lcobucci\JWT\Builder` was updated to be `@immutable` done [here](https://github.com/lcobucci/jwt/pull/979). This change did not seem to cause test failures but did show up in the upgrade guide. I've updated its usage in the `Lcobucci` provider to reassign return values

Note: I suppose that the addition of the `Builder` return type could be a BC break if something is extending the class? I can remove that if desired
## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
