### PR TITLE
SetSecret regenerates config with new secret in the Lcobucci provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
+- SetSecret regenerates config with new secret in the Lcobucci provider
 
 ### Added
 - Support for lcobucci/jwt^5.0 (and dropped support for ^4.0)

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -74,7 +74,18 @@ class Lcobucci extends Provider implements JWT
         $config = null
     ) {
         parent::__construct($secret, $algo, $keys);
+        $this->generateConfig($config);
+    }
 
+    /**
+     * Generate the config.
+     *
+     * @param Configuration $config optional, to pass an existing configuration to be used
+     *
+     * @return $this
+     */
+    private function generateConfig($config = null)
+    {
         $this->signer = $this->getSigner();
 
         if (!is_null($config)) {
@@ -89,6 +100,21 @@ class Lcobucci extends Provider implements JWT
                 new SignedWith($this->signer, $this->getVerificationKey()),
             );
         }
+    }
+
+    /**
+     * Set the secret used to sign the token and regenerate the config using the secret.
+     *
+     * @param string $secret
+     *
+     * @return $this
+     */
+    public function setSecret($secret)
+    {
+        $this->secret = $secret;
+        $this->generateConfig();
+
+        return $this;
     }
 
     /**

--- a/src/Providers/JWT/Lcobucci.php
+++ b/src/Providers/JWT/Lcobucci.php
@@ -82,7 +82,7 @@ class Lcobucci extends Provider implements JWT
      *
      * @param Configuration $config optional, to pass an existing configuration to be used
      *
-     * @return $this
+     * @return void
      */
     private function generateConfig($config = null)
     {

--- a/tests/Providers/JWT/LcobucciTest.php
+++ b/tests/Providers/JWT/LcobucciTest.php
@@ -189,6 +189,26 @@ class LcobucciTest extends AbstractTestCase
         $this->getProvider('secret', 'AlgorithmWrong')->decode('foo.bar.baz');
     }
 
+    public function testItShouldThrowAExceptionWhenTheSecretHasBeenUpdatedAndAnOldTokenIsUsed()
+    {
+        $orignal_secret = 'OF8SQY475aF8uiRuWunK9ZO6VdZDBemk';
+        $new_secret = 'vsd1z800ApIihL6HVNyhbGLRyBLD74sZ';
+
+        $payload = ['sub' => '1', 'exp' => $this->testNowTimestamp + 3600, 'iat' => $this->testNowTimestamp, 'iss' => '/foo'];
+
+        $provider = new Lcobucci($orignal_secret, 'HS256', []);
+        $token = $provider->encode($payload);
+
+        $this->assertSame($payload, $provider->decode($token));
+
+        $provider->setSecret($new_secret);
+
+        $this->expectException(TokenInvalidException::class);
+        $this->expectExceptionMessage('Token Signature could not be verified.');
+
+        $provider->decode($token);
+    }
+
     public function testItShouldReturnThePublicKey()
     {
         $provider = $this->getProvider(


### PR DESCRIPTION
## Description

The secret that is set using the SetSecret method of the Lcobucci Provider is not used when encoding/decoding.
This is due to the secret only being applied when the config is generated when the provider is first being constructed.

To fix the issue, the config needs to be regenerated after the new Secret has been set.

[Fixes # 226](https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/226)

## Checklist:

- [Y ] I've added tests for my changes or tests are not applicable
- [Y ] I've changed documentations or changes are not required
- [Y ] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
