### PR TITLE
Fix to refresh the IAT when a token is refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
 - SetSecret regenerates config with new secret in the Lcobucci provider
+- Refresh iat claim when refreshing a token
 
 ### Added
 - Support for lcobucci/jwt^5.0 (and dropped support for ^4.0)

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -17,6 +17,7 @@ use PHPOpenSourceSaver\JWTAuth\Exceptions\JWTException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenBlacklistedException;
 use PHPOpenSourceSaver\JWTAuth\Support\CustomClaims;
 use PHPOpenSourceSaver\JWTAuth\Support\RefreshFlow;
+use PHPOpenSourceSaver\JWTAuth\Support\Utils;
 
 class Manager
 {
@@ -181,7 +182,7 @@ class Manager
             $persistentClaims,
             [
                 'sub' => $payload['sub'],
-                'iat' => $payload['iat'],
+                'iat' => Utils::now()->timestamp,
             ]
         );
     }

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -12,6 +12,7 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test;
 
+use Illuminate\Support\Carbon;
 use Mockery\LegacyMockInterface;
 use PHPOpenSourceSaver\JWTAuth\Blacklist;
 use PHPOpenSourceSaver\JWTAuth\Claims\Collection;
@@ -181,6 +182,42 @@ class ManagerTest extends AbstractTestCase
         // $this->assertArrayHasKey('ref', $payload);
         $this->assertInstanceOf(Token::class, $token);
         $this->assertEquals('baz.bar.foo', $token);
+    }
+
+    public function testBuildRefreshClaimsMethodWillRefreshTheIAT()
+    {
+        $claims = [
+            new Subject(1),
+            new Issuer('http://example.com'),
+            new Expiration($this->testNowTimestamp - 3600),
+            new NotBefore($this->testNowTimestamp),
+            new IssuedAt($this->testNowTimestamp),
+            new JwtId('foo'),
+        ];
+        $collection = Collection::make($claims);
+
+        $this->validator->shouldReceive('setRefreshFlow->check')->andReturn($collection);
+        $payload = new Payload($collection, $this->validator);
+
+        $managerClass = new \ReflectionClass(Manager::class);
+        $buildRefreshClaimsMethod = $managerClass->getMethod('buildRefreshClaims');
+        $buildRefreshClaimsMethod->setAccessible(true);
+        $managerInstance = new Manager($this->jwt, $this->blacklist, $this->factory);
+
+        $firstResult = $buildRefreshClaimsMethod->invokeArgs($managerInstance, [$payload]);
+        Carbon::setTestNow(Carbon::now()->addMinutes(2));
+        $secondResult = $buildRefreshClaimsMethod->invokeArgs($managerInstance, [$payload]);
+
+        $this->assertIsInt($firstResult['iat']);
+        $this->assertIsInt($secondResult['iat']);
+
+        $carbonTimestamp = Carbon::createFromTimestamp($firstResult['iat']);
+        $this->assertInstanceOf(Carbon::class, $carbonTimestamp);
+
+        $carbonTimestamp = Carbon::createFromTimestamp($secondResult['iat']);
+        $this->assertInstanceOf(Carbon::class, $carbonTimestamp);
+
+        $this->assertNotEquals($firstResult['iat'], $secondResult['iat']);
     }
 
     /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses the issue #249, refreshing the IAT claim when refreshing a token

<!-- Describe your changes in detail -->
<!-- You can also attach related issues by uncommenting -->
Fixes #249 


## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
