### PR TITLE
feat: add getUserId method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can find and compare releases at the GitHub release page.
 
 ### Added
 - Support for lcobucci/jwt^5.0 (and dropped support for ^4.0)
+- New `getUserId` method
 
 ## [2.3.0] 2024-05-09
 

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -109,6 +109,26 @@ class JWTGuard implements Guard
     }
 
     /**
+     * @return int|string|null
+     */
+    public function getUserId()
+    {
+        if (null !== $this->user) {
+            return $this->user->getAuthIdentifier();
+        }
+
+        if (
+            $this->jwt->setRequest($this->request)->getToken()
+            && ($payload = $this->jwt->check(true))
+            && $this->validateSubject()
+        ) {
+            return $payload['sub'];
+        }
+
+        return null;
+    }
+
+    /**
      * Get the currently authenticated user or throws an exception.
      *
      * @return Authenticatable


### PR DESCRIPTION
## Description

Hello 👋🏽 

This PR adds a new method to the guard called `getUserId`

The need for this is explained in the original issue [here](https://github.com/tymondesigns/jwt-auth/issues/2220).

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
