### PR TITLE
Fixes #258 whereby logout fails if the JWT already being used has exp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
-- SetSecret regenerates config with new secret in the Lcobucci provider
+
+### Added
+
+### Removed
+
+## [2.6.0] 2024-07-11
+
+### Added
+- New `getUserId` method
+
+## [2.5.0] 2024-07-03
+
+### Added
 - Refresh iat claim when refreshing a token
+
+## [2.4.0] 2024-05-27
 
 ### Added
 - Support for lcobucci/jwt^5.0 (and dropped support for ^4.0)
-- New `getUserId` method
+- SetSecret regenerates config with new secret in the Lcobucci provider
 
 ## [2.3.0] 2024-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can find and compare releases at the GitHub release page.
 ## [Unreleased]
 
 ### Added
+- Fixes #259 - Can't logout with an expired token
 
 ### Removed
 

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -200,7 +200,11 @@ class JWTGuard implements Guard
      */
     public function logout($forceForever = false)
     {
-        $this->requireToken()->invalidate($forceForever);
+        try {
+            $this->requireToken()->invalidate($forceForever);
+        } catch (JWTException $e) {
+            // Proceed with the logout as normal if we can't invalidate the token
+        }
 
         $this->fireLogoutEvent($this->user);
 


### PR DESCRIPTION
## Description

Fixes #258 by catching our exceptions on token invalidation and proceeding with framework logout.


## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
