### PR TITLE
Cater for both Carbon v2 and v3 - issue #260

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -27,6 +27,9 @@ jobs:
             laravel: 11.*
             stability: prefer-stable
             coverage: xdebug
+          - php: 8.3
+            laravel: 11.*
+            nesbot/carbon: 3.*
 
     name: 'P${{ matrix.php }} L${{ matrix.laravel }} ${{ matrix.stability }} c:${{ matrix.coverage }}'
 
@@ -54,6 +57,11 @@ jobs:
       - name: Set Minimum Laravel ${{ matrix.laravel }} Versions
         run: |
           composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-progress --no-update
+
+      - name: Set carbon version
+        if: ${{ matrix.carbon }}
+        run: |
+          composer require "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-progress --no-update
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,7 +29,7 @@ jobs:
             coverage: xdebug
           - php: 8.3
             laravel: 11.*
-            nesbot/carbon: 3.*
+            carbon: 3.*
 
     name: 'P${{ matrix.php }} L${{ matrix.laravel }} ${{ matrix.stability }} c:${{ matrix.coverage }}'
 

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -95,7 +95,14 @@ class Blacklist
         // get the latter of the two expiration dates and find
         // the number of minutes until the expiration date,
         // plus 1 minute to avoid overlap
-        return round($exp->max($iat->addMinutes($this->refreshTTL))->addMinute()->diffInRealMinutes(null, true));
+        $intermediateResult = $exp->max($iat->addMinutes($this->refreshTTL))->addMinute();
+
+        // Handle Carbon 2 vs 3 deprecation of "Real" diff functions, see https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/260
+        if (method_exists($intermediateResult, 'diffInRealMinutes')) {
+            return round($intermediateResult->diffInRealMinutes(null, true));
+        } else {
+            return (int) round($intermediateResult->diffInMinutes(null, true));
+        }
     }
 
     /**


### PR DESCRIPTION
Carbon v3 deprecates the "diff real" functions, and throws a deprecated. It automatically routes the request to the function it thinks best, which in this case is `diffInRealMinutes` (see Carbon\Traits\Date::callDiffAlias() for details on why).

Since we are aiming to support both, I split the code into a conditional, calling the appropriate function. It also now returns a float, so it's necessary to cast round result to int - as it too will return a float.

I also added a test pipeline specifically for carbon 3, since nothing requires it specifically right now.

## Description

Fixes #260 

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
