### PR TITLE
fix explode(): Argument #2 ($string) must be of type string, array given

### DIFF
--- a/src/Validators/TokenValidator.php
+++ b/src/Validators/TokenValidator.php
@@ -39,7 +39,12 @@ class TokenValidator extends Validator
      */
     protected function validateStructure($token)
     {
-        $parts = explode('.', $token);
+        if (is_string($token)) {
+            $parts = explode('.', $token);
+        } else {
+            throw new \InvalidArgumentException('Expected token to be a string.');
+        }
+
 
         if (3 !== count($parts)) {
             throw new TokenInvalidException('Wrong number of segments');

--- a/src/Validators/TokenValidator.php
+++ b/src/Validators/TokenValidator.php
@@ -37,14 +37,9 @@ class TokenValidator extends Validator
      *
      * @throws TokenInvalidException
      */
-    protected function validateStructure($token)
+    protected function validateStructure(string $token)
     {
-        if (is_string($token)) {
-            $parts = explode('.', $token);
-        } else {
-            throw new TokenInvalidException('Expected token to be a string');
-        }
-
+        $parts = explode('.', $token);
 
         if (3 !== count($parts)) {
             throw new TokenInvalidException('Wrong number of segments');

--- a/src/Validators/TokenValidator.php
+++ b/src/Validators/TokenValidator.php
@@ -42,7 +42,7 @@ class TokenValidator extends Validator
         if (is_string($token)) {
             $parts = explode('.', $token);
         } else {
-            throw new \InvalidArgumentException('Expected token to be a string.');
+            throw new TokenInvalidException('Expected token to be a string');
         }
 
 

--- a/tests/Validators/TokenValidatorTest.php
+++ b/tests/Validators/TokenValidatorTest.php
@@ -52,11 +52,12 @@ class TokenValidatorTest extends AbstractTestCase
         $this->validator->check($token);
     }
 
-    public function testItShouldThrowAnExceptionTokenIsNotString()
+    #[DataProviderExternal(TokenValidatorTest::class, 'dataProviderInvalidTokenType')]
+    public function testItShouldThrowAnExceptionIfTokenIsNotString($token)
     {
         $this->expectException(TypeError::class);
 
-        $this->validator->check(['array']);
+        $this->validator->check($token);
     }
 
     #[DataProviderExternal(TokenValidatorTest::class, 'dataProviderTokensWithWrongSegmentsNumber')]
@@ -93,6 +94,14 @@ class TokenValidatorTest extends AbstractTestCase
             ['one.two'],
             ['one.two.three.four'],
             ['one.two.three.four.five'],
+        ];
+    }
+
+    public static function dataProviderInvalidTokenType()
+    {
+        return [
+            ['array'],
+            1,
         ];
     }
 }

--- a/tests/Validators/TokenValidatorTest.php
+++ b/tests/Validators/TokenValidatorTest.php
@@ -12,10 +12,11 @@
 
 namespace PHPOpenSourceSaver\JWTAuth\Test\Validators;
 
-use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
+use TypeError;
 use PHPOpenSourceSaver\JWTAuth\Test\AbstractTestCase;
-use PHPOpenSourceSaver\JWTAuth\Validators\TokenValidator;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPOpenSourceSaver\JWTAuth\Validators\TokenValidator;
+use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 
 class TokenValidatorTest extends AbstractTestCase
 {
@@ -51,13 +52,11 @@ class TokenValidatorTest extends AbstractTestCase
         $this->validator->check($token);
     }
 
-    #[DataProviderExternal(TokenValidatorTest::class, 'dataProviderMalformedTokens')]
-    public function testItShouldThrowAnExceptionWhenProvidingAMalformedToken($token)
+    public function testItShouldThrowAnExceptionTokenIsNotString()
     {
-        $this->expectException(TokenInvalidException::class);
-        $this->expectExceptionMessage('Expected token to be a string');
+        $this->expectException(TypeError::class);
 
-        $this->validator->check($token);
+        $this->validator->check(['array']);
     }
 
     #[DataProviderExternal(TokenValidatorTest::class, 'dataProviderTokensWithWrongSegmentsNumber')]
@@ -85,7 +84,6 @@ class TokenValidatorTest extends AbstractTestCase
             ['..'],
             [' . . '],
             [' one . two . three '],
-            [['array']],
         ];
     }
 

--- a/tests/Validators/TokenValidatorTest.php
+++ b/tests/Validators/TokenValidatorTest.php
@@ -51,6 +51,15 @@ class TokenValidatorTest extends AbstractTestCase
         $this->validator->check($token);
     }
 
+    #[DataProviderExternal(TokenValidatorTest::class, 'dataProviderMalformedTokens')]
+    public function testItShouldThrowAnExceptionWhenProvidingAMalformedToken($token)
+    {
+        $this->expectException(TokenInvalidException::class);
+        $this->expectExceptionMessage('Expected token to be a string');
+
+        $this->validator->check($token);
+    }
+
     #[DataProviderExternal(TokenValidatorTest::class, 'dataProviderTokensWithWrongSegmentsNumber')]
     public function testItShouldReturnFalseWhenProvidingATokenWithWrongSegmentsNumber($token)
     {
@@ -76,6 +85,7 @@ class TokenValidatorTest extends AbstractTestCase
             ['..'],
             [' . . '],
             [' one . two . three '],
+            [['array']],
         ];
     }
 


### PR DESCRIPTION
fix explode(): Argument #2 ($string) must be of type string, array given in TokenValidator

## Description

There is no check if the token sent is a string in any of the parsers, I know this should be done from apps that use this package, but for better error handling especially when calling ```JWTAuth::getToken()``` from outside this package 

- to fix this, I add a check and throw an exception if $token is not a string

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
