### PR TITLE
Fix Carbon not accepting string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ You can find and compare releases at the GitHub release page.
 
 ## [Unreleased]
 
-### Added
+### Fixed
 - Fixes #259 - Can't logout with an expired token
+- Fixed #271 - Changing JWT_TTL in .env doesn't work
+
+### Added
 - Add `cookie_key_name` config to customize cookie name for authentication
 
 ### Removed

--- a/config/config.php
+++ b/config/config.php
@@ -89,7 +89,7 @@ return [
     |
     */
 
-    'ttl' => env('JWT_TTL', 60),
+    'ttl' => (int) env('JWT_TTL', 60),
 
     /*
     |--------------------------------------------------------------------------
@@ -108,7 +108,7 @@ return [
     |
     */
 
-    'refresh_ttl' => env('JWT_REFRESH_TTL', 20160),
+    'refresh_ttl' => (int) env('JWT_REFRESH_TTL', 20160),
 
     /*
     |--------------------------------------------------------------------------
@@ -196,7 +196,7 @@ return [
     |
     */
 
-    'leeway' => env('JWT_LEEWAY', 0),
+    'leeway' => (int) env('JWT_LEEWAY', 0),
 
     /*
     |--------------------------------------------------------------------------
@@ -223,7 +223,7 @@ return [
     |
     */
 
-    'blacklist_grace_period' => env('JWT_BLACKLIST_GRACE_PERIOD', 0),
+    'blacklist_grace_period' => (int) env('JWT_BLACKLIST_GRACE_PERIOD', 0),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Carbon methods are strongly typed. So, you can't provide `seconds` as a `string`.
This is what you get if you try to override `JWT_TTL` in your `.env`:

```
Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given
```

This PR fixes the issue by casting the config after reading it from `.env` as is common in Laravel's config files.

Fixes https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/271

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
