### PR TITLE
don't show jwt secret if show option is false even if the key is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can find and compare releases at the GitHub release page.
 ### Fixed
 - Fixes #259 - Can't logout with an expired token
 - Fixed #271 - Changing JWT_TTL in .env doesn't work
+- Fixes #274 - Do not display jwt secret on console after successfully generated a new key
 
 ### Added
 - Add `cookie_key_name` config to customize cookie name for authentication

--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -73,7 +73,7 @@ class JWTGenerateSecretCommand extends Command
 
         if ($updated) {
             $this->updateEnvEntry('JWT_ALGO', 'HS256');
-            $this->displayKey($key);
+            $this->info('jwt-auth secret set successfully.');
         }
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
Fixes #274 
Adding a new option in jwt secret generator command for not showing the newly generated key.
<!-- You can also attach related issues by uncommenting -->
<!-- Fixes # (issue) -->

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
