### PR TITLE
Override "id" method in JWTGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can find and compare releases at the GitHub release page.
 
 ### Added
 - Add `cookie_key_name` config to customize cookie name for authentication
+- Delegate `Auth::id()` calls to the newly added `getUserId` method
 
 ### Removed
 

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -129,6 +129,16 @@ class JWTGuard implements Guard
     }
 
     /**
+     * Get the ID for the currently authenticated user.
+     *
+     * @return int|string|null
+     */
+    public function id()
+    {
+        $this->getUserId();
+    }
+
+    /**
      * Get the currently authenticated user or throws an exception.
      *
      * @return Authenticatable

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -135,15 +135,7 @@ class JWTGuard implements Guard
      */
     public function id()
     {
-        if ($id = $this->getUserId()) {
-            return $id;
-        }
-
-        if ($user = $this->user()) {
-            return $user->getAuthIdentifier();
-        }
-
-        return null;
+        return $this->getUserId();
     }
 
     /**

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -135,7 +135,15 @@ class JWTGuard implements Guard
      */
     public function id()
     {
-        $this->getUserId();
+        if ($id = $this->getUserId()) {
+            return $id;
+        }
+
+        if ($this->user()) {
+            return $this->user()->getAuthIdentifier();
+        }
+
+        return null;
     }
 
     /**

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -139,8 +139,8 @@ class JWTGuard implements Guard
             return $id;
         }
 
-        if ($this->user()) {
-            return $this->user()->getAuthIdentifier();
+        if ($user = $this->user()) {
+            return $user->getAuthIdentifier();
         }
 
         return null;

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -193,6 +193,35 @@ class JWTGuardTest extends AbstractTestCase
         $this->assertSame(1, $this->guard->getUserId());
     }
 
+    public function testItShouldGetTheAuthenticatedUserIdNativelyIfAValidTokenIsProvided()
+    {
+        $payload = \Mockery::mock(Payload::class);
+        $payload->shouldReceive('offsetGet')->once()->with('sub')->andReturn(1);
+
+        $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
+        $this->jwt->shouldReceive('getToken')->once()->andReturn('foo.bar.baz');
+        $this->jwt->shouldReceive('check')->once()->with(true)->andReturn($payload);
+        $this->jwt->shouldReceive('checkSubjectModel')
+            ->once()
+            ->with('\PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub')
+            ->andReturn(true);
+
+        $this->provider->shouldReceive('getModel')
+            ->once()
+            ->andReturn('\PHPOpenSourceSaver\JWTAuth\Test\Stubs\LaravelUserStub');
+
+        $this->assertSame(1, $this->guard->id());
+    }
+
+    public function testIdShouldFallBackToUserMethodIfATokenIsNotProvidedInFeatureTestScenarios()
+    {
+        $this->eventDispatcher->shouldReceive('dispatch')->once();
+
+        $this->guard->setUser(new LaravelUserStub());
+
+        $this->assertSame(1, $this->guard->id());
+    }
+
     public function testItShouldReturnNullForUserIdIfNoTokenIsProvided()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);

--- a/tests/Stubs/LaravelUserStub.php
+++ b/tests/Stubs/LaravelUserStub.php
@@ -24,6 +24,7 @@ class LaravelUserStub extends UserStub implements Authenticatable, JWTSubject
 
     public function getAuthIdentifier()
     {
+        return $this->getJWTIdentifier();
     }
 
     public function getAuthPasswordName(): string


### PR DESCRIPTION
## Description

Hiya! 👋

PR #257 added a nice `getUserId` method to prevent database round-trips. However, I'm not really sure why he decided to go this route because all authentication guards implementing the `GuardHelpers` trait already contain such a method (which is also the one being called when you use `Auth::id()`).

This PR simply adds this functionality to the `id` method, so you can also benefit from the eliminated database round-trips when using `auth()->id()` or `Auth::id()`.

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
