### PR TITLE
Updates for Laravel 12 

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,13 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         coverage: [none]
-        exclude:
-          - laravel: 11.*
-            php: 8.1
         include:
           - php: 8.3
             laravel: 11.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-You can find and compare releases at the GitHub release page.
+You can find and compare releases at the [GitHub release page](https://github.com/PHP-Open-Source-Saver/jwt-auth/releases).
 
 ## [Unreleased]
 
-### Fixed
-- Fixes #259 - Can't logout with an expired token
-- Fixed #271 - Changing JWT_TTL in .env doesn't work
-- Fixes #274 - Do not display jwt secret on console after successfully generated a new key
+## [2.8.0] 2025-02-12 (TBA)
+
+### Added
+- Adds support for Laravel 12
+- Adds CI testing for PHP 8.4
+
+### Removed
+
+- Dropping support for PHP 8.1, if you are still on this version, please update your PHP version in order to use the latest version of this package.
+
+## [2.7.2] 2024-09-28
 
 ### Added
 - Add `cookie_key_name` config to customize cookie name for authentication
 
-### Removed
+## [2.7.0] 2024-07-24
+
+### Fixed
+- Support for Carbon 3 alongside Carbon 2
 
 ## [2.6.0] 2024-07-11
 

--- a/composer.json
+++ b/composer.json
@@ -30,25 +30,30 @@
             "name": "Fabio William Conceição",
             "email": "messhias@gmail.com",
             "role": "Developer"
+        },
+        {
+            "name": "Max Snow",
+            "email": "contact@maxsnow.me",
+            "role": "Developer"
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "illuminate/auth": "^10|^11",
-        "illuminate/contracts": "^10|^11",
-        "illuminate/http": "^10|^11",
-        "illuminate/support": "^10|^11",
+        "illuminate/auth": "^10|^11|^12",
+        "illuminate/contracts": "^10|^11|^12",
+        "illuminate/http": "^10|^11|^12",
+        "illuminate/support": "^10|^11|^12",
         "lcobucci/jwt": "^5.0",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^2.0|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
-        "illuminate/console": "^10|^11",
-        "illuminate/routing": "^10|^11",
-        "orchestra/testbench": "^8|^9",
-        "mockery/mockery": "^1.4.4",
+        "illuminate/console": "^10|^11|^12",
+        "illuminate/routing": "^10|^11|^12",
+        "orchestra/testbench": "^8|^9|^10",
+        "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^2",
         "phpunit/phpunit": "^10.5|^11"
     },


### PR DESCRIPTION
**Blockers**
 - Need to wait until orchestra techbench releases version 10 

**Changes**
- Updates to package for Laravel 12 (mostly CI)
- Removing PHP 8.1, no longer supported

**Todo**
- [x] I've added tests for my changes or tests are not applicable
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
