### PR TITLE
Draft: Adds strong typing, more typing, php 8.2 features

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    cacheDirectory=".phpunit.result.cache"
+    failOnRisky="true"
+    failOnWarning="true"
+>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="jwt-auth Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <file>src/Providers/LumenServiceProvider.php</file>
+      <directory suffix=".php">src/Facades/</directory>
+      <directory suffix=".php">src/Console/</directory>
+    </exclude>
+  </source>
+</phpunit>

--- a/src/Claims/Claim.php
+++ b/src/Claims/Claim.php
@@ -21,22 +21,20 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
 {
     /**
      * The claim name.
-     *
-     * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * The claim value.
      */
-    private $value;
+    private mixed $value;
 
     /**
      * @return void
      *
      * @throws InvalidClaimException
      */
-    public function __construct($value)
+    public function __construct(mixed $value)
     {
         $this->setValue($value);
     }
@@ -44,11 +42,9 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
     /**
      * Set the claim value, and call a validate method.
      *
-     * @return $this
-     *
      * @throws InvalidClaimException
      */
-    public function setValue($value)
+    public function setValue(mixed $value): static
     {
         $this->value = $this->validateCreate($value);
 
@@ -58,7 +54,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
     /**
      * Get the claim value.
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }
@@ -70,7 +66,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): static
     {
         $this->name = $name;
 
@@ -82,17 +78,15 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
      * Validate the claim in a standalone Claim context.
-     *
-     * @return bool
      */
-    public function validateCreate($value)
+    public function validateCreate(mixed $value): mixed
     {
         return $value;
     }
@@ -102,42 +96,33 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
      *
      * @return bool
      */
-    public function validatePayload()
+    public function validatePayload(): mixed
     {
         return $this->getValue();
     }
 
     /**
      * Validate the Claim within a refresh context.
-     *
-     * @param int $refreshTTL
-     *
-     * @return bool
      */
-    public function validateRefresh($refreshTTL)
+    public function validateRefresh(int $refreshTTL): bool
     {
         return $this->getValue();
     }
 
     /**
      * Checks if the value matches the claim.
-     *
-     * @param bool $strict
-     *
-     * @return bool
      */
-    public function matches($value, $strict = true)
+    public function matches(mixed $value, bool $strict = true): bool
     {
         return $strict ? $this->value === $value : $this->value == $value;
     }
 
     /**
      * Convert the object into something JSON serializable.
-     *
-     * @return array
      */
+    // @todo: what the hell is this attribute
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -147,7 +132,7 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [$this->getName() => $this->getValue()];
     }
@@ -156,20 +141,16 @@ abstract class Claim implements Arrayable, ClaimContract, Jsonable, \JsonSeriali
      * Get the claim as JSON.
      *
      * @param int $options
-     *
-     * @return string
      */
-    public function toJson($options = JSON_UNESCAPED_SLASHES)
+    public function toJson($options = JSON_UNESCAPED_SLASHES): string
     {
         return json_encode($this->toArray(), $options);
     }
 
     /**
      * Get the payload as a string.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toJson();
     }

--- a/src/Claims/Custom.php
+++ b/src/Claims/Custom.php
@@ -17,15 +17,14 @@ use PHPOpenSourceSaver\JWTAuth\Exceptions\InvalidClaimException;
 class Custom extends Claim
 {
     /**
-     * @param string $name
-     *
-     * @return void
+     * Creates a custom claim
      *
      * @throws InvalidClaimException
      */
-    public function __construct($name, $value)
+    public function __construct(string $name, mixed $value)
     {
         parent::__construct($value);
+
         $this->setName($name);
     }
 }

--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -20,25 +20,19 @@ use PHPOpenSourceSaver\JWTAuth\Support\Utils;
 class Factory
 {
     /**
-     * The request.
-     *
-     * @var Request
+     * The Laravel request.
      */
-    protected $request;
+    protected Request $request;
 
     /**
-     * The TTL.
-     *
-     * @var int|null
+     * The time to live in minutes.
      */
-    protected $ttl = 60;
+    protected int $ttl = 60;
 
     /**
      * Time leeway in seconds.
-     *
-     * @var int
      */
-    protected $leeway = 0;
+    protected int $leeway = 0;
 
     /**
      * The classes map.
@@ -179,11 +173,9 @@ class Factory
     }
 
     /**
-     * Set the request instance.
-     *
-     * @return $this
+     * Set the Laravel request instance.
      */
-    public function setRequest(Request $request)
+    public function setRequest(Request $request): self
     {
         $this->request = $request;
 
@@ -192,36 +184,26 @@ class Factory
 
     /**
      * Set the token ttl (in minutes).
-     *
-     * @param int|null $ttl
-     *
-     * @return $this
      */
-    public function setTTL($ttl)
+    public function setTTL(int $ttl): self
     {
-        $this->ttl = $ttl ? (int) $ttl : $ttl;
+        $this->ttl = $ttl;
 
         return $this;
     }
 
     /**
      * Get the token ttl.
-     *
-     * @return int|null
      */
-    public function getTTL()
+    public function getTTL(): int
     {
         return $this->ttl;
     }
 
     /**
      * Set the leeway in seconds.
-     *
-     * @param int $leeway
-     *
-     * @return $this
      */
-    public function setLeeway($leeway)
+    public function setLeeway(int $leeway): self
     {
         $this->leeway = $leeway;
 

--- a/src/Claims/Factory.php
+++ b/src/Claims/Factory.php
@@ -39,7 +39,7 @@ class Factory
      *
      * @var array
      */
-    private $classMap = [
+    private array $classMap = [
         'aud' => Audience::class,
         'exp' => Expiration::class,
         'iat' => IssuedAt::class,
@@ -51,8 +51,6 @@ class Factory
 
     /**
      * Constructor.
-     *
-     * @return void
      */
     public function __construct(Request $request)
     {
@@ -62,13 +60,9 @@ class Factory
     /**
      * Get the instance of the claim when passing the name and value.
      *
-     * @param string $name
-     *
-     * @return Claim
-     *
      * @throws InvalidClaimException
      */
-    public function get($name, $value)
+    public function get(string $name, mixed $value): Custom
     {
         if ($this->has($name)) {
             $claim = new $this->classMap[$name]($value);
@@ -83,12 +77,8 @@ class Factory
 
     /**
      * Check whether the claim exists.
-     *
-     * @param string $name
-     *
-     * @return bool
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return array_key_exists($name, $this->classMap);
     }
@@ -96,76 +86,57 @@ class Factory
     /**
      * Generate the initial value and return the Claim instance.
      *
-     * @param string $name
-     *
-     * @return Claim
-     *
      * @throws InvalidClaimException
      */
-    public function make($name)
+    public function make(string $name): Claim
     {
         return $this->get($name, $this->$name());
     }
 
     /**
      * Get the Issuer (iss) claim.
-     *
-     * @return string
      */
-    public function iss()
+    public function iss(): string
     {
-        return $this->request->url();
+        return $this->request->url() ?? '';
     }
 
     /**
      * Get the Issued At (iat) claim.
-     *
-     * @return int
      */
-    public function iat()
+    public function iat(): int
     {
         return Utils::now()->getTimestamp();
     }
 
     /**
-     * Get the Expiration (exp) claim.
-     *
-     * @return int
+     * Get the Expiration (exp) claim as a unix timestamp
      */
-    public function exp()
+    public function exp(): int
     {
         return Utils::now()->addMinutes($this->ttl)->getTimestamp();
     }
 
     /**
-     * Get the Not Before (nbf) claim.
-     *
-     * @return int
+     * Get the Not Before (nbf) claim as a unix timestamp
      */
-    public function nbf()
+    public function nbf(): int
     {
         return Utils::now()->getTimestamp();
     }
 
     /**
      * Get the JWT Id (jti) claim.
-     *
-     * @return string
      */
-    public function jti()
+    public function jti(): string
     {
         return Str::random();
     }
 
     /**
      * Add a new claim mapping.
-     *
-     * @param string $name
-     * @param string $classPath
-     *
-     * @return $this
      */
-    public function extend($name, $classPath)
+    public function extend(string $name, string $classPath): self
     {
         $this->classMap[$name] = $classPath;
 

--- a/src/Claims/NotBefore.php
+++ b/src/Claims/NotBefore.php
@@ -18,12 +18,12 @@ class NotBefore extends Claim
 {
     use DatetimeTrait;
 
-    protected $name = 'nbf';
+    protected string $name = 'nbf';
 
     /**
      * @throws TokenInvalidException
      */
-    public function validatePayload()
+    public function validatePayload(): void
     {
         if ($this->isFuture($this->getValue())) {
             throw new TokenInvalidException('Not Before (nbf) timestamp cannot be in the future');

--- a/src/Contracts/Claim.php
+++ b/src/Contracts/Claim.php
@@ -18,38 +18,28 @@ interface Claim
 {
     /**
      * Set the claim value, and call a validate method.
-     *
-     * @return $this
-     *
+
      * @throws InvalidClaimException
      */
-    public function setValue($value);
+    public function setValue(mixed $value): self;
 
     /**
      * Get the claim value.
      */
-    public function getValue();
+    public function getValue(): mixed;
 
     /**
      * Set the claim name.
-     *
-     * @param string $name
-     *
-     * @return $this
      */
-    public function setName($name);
+    public function setName(string $name): self;
 
     /**
      * Get the claim name.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
-     * Validate the Claim value.
-     *
-     * @return bool
+     * Validate the Claim value, and return it
      */
-    public function validateCreate($value);
+    public function validateCreate(mixed $value): mixed;
 }

--- a/src/Contracts/Http/Parser.php
+++ b/src/Contracts/Http/Parser.php
@@ -17,9 +17,7 @@ use Illuminate\Http\Request;
 interface Parser
 {
     /**
-     * Parse the request.
-     *
-     * @return string|null
+     * Parse the request, and return the desired value from it.
      */
-    public function parse(Request $request);
+    public function parse(Request $request): string|null;
 }

--- a/src/Contracts/Providers/Storage.php
+++ b/src/Contracts/Providers/Storage.php
@@ -20,7 +20,7 @@ interface Storage
      *
      * @return void
      */
-    public function add($key, $value, $minutes);
+    public function add(string $key, $value, int $minutes);
 
     /**
      * @param string $key

--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -300,14 +300,15 @@ abstract class AbstractServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerClaimFactory()
+    protected function registerClaimFactory(): void
     {
         $this->app->singleton('tymon.jwt.claim.factory', function ($app) {
             $factory = new ClaimFactory($app['request']);
             $app->refresh('request', $factory, 'setRequest');
+            $config = $app->make('config');
 
-            return $factory->setTTL($app->make('config')->get('jwt.ttl'))
-                           ->setLeeway($app->make('config')->get('jwt.leeway'));
+            return $factory->setTTL((int) $config->get('jwt.ttl'))
+                           ->setLeeway((int) $config->get('jwt.leeway'));
         });
     }
 

--- a/src/Providers/JWT/Provider.php
+++ b/src/Providers/JWT/Provider.php
@@ -36,14 +36,11 @@ abstract class Provider
     /**
      * Constructor.
      *
-     * @param string $secret
-     * @param string $algo
-     *
-     * @return void
+     * @throws SecretMissingException
      */
-    public function __construct($secret, $algo, array $keys)
+    public function __construct(?string $secret, string $algo, array $keys)
     {
-        if (is_null($secret) && (is_null($keys['public']) || is_null($keys['private']))) {
+        if (is_null($secret) && (empty($keys['public']) || empty($keys['private']))) {
             throw new SecretMissingException();
         }
 
@@ -54,12 +51,8 @@ abstract class Provider
 
     /**
      * Set the algorithm used to sign the token.
-     *
-     * @param string $algo
-     *
-     * @return $this
      */
-    public function setAlgo($algo)
+    public function setAlgo(string $algo): self
     {
         $this->algo = $algo;
 
@@ -68,22 +61,16 @@ abstract class Provider
 
     /**
      * Get the algorithm used to sign the token.
-     *
-     * @return string
      */
-    public function getAlgo()
+    public function getAlgo(): string
     {
         return $this->algo;
     }
 
     /**
      * Set the secret used to sign the token.
-     *
-     * @param string $secret
-     *
-     * @return $this
      */
-    public function setSecret($secret)
+    public function setSecret(string $secret): self
     {
         $this->secret = $secret;
 
@@ -92,20 +79,16 @@ abstract class Provider
 
     /**
      * Get the secret used to sign the token.
-     *
-     * @return string
      */
-    public function getSecret()
+    public function getSecret(): string
     {
         return $this->secret;
     }
 
     /**
      * Set the keys used to sign the token.
-     *
-     * @return $this
      */
-    public function setKeys(array $keys)
+    public function setKeys(array $keys): self
     {
         $this->keys = $keys;
 
@@ -115,10 +98,8 @@ abstract class Provider
     /**
      * Get the array of keys used to sign tokens
      * with an asymmetric algorithm.
-     *
-     * @return array
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         return $this->keys;
     }
@@ -148,10 +129,8 @@ abstract class Provider
     /**
      * Get the passphrase used to sign tokens
      * with an asymmetric algorithm.
-     *
-     * @return string
      */
-    public function getPassphrase()
+    public function getPassphrase(): string
     {
         return Arr::get($this->keys, 'passphrase');
     }
@@ -180,9 +159,7 @@ abstract class Provider
      * Determine if the algorithm is asymmetric, and thus
      * requires a public/private key combo.
      *
-     * @return bool
-     *
      * @throws JWTException
      */
-    abstract protected function isAsymmetric();
+    abstract protected function isAsymmetric(): bool;
 }

--- a/src/Support/CustomClaims.php
+++ b/src/Support/CustomClaims.php
@@ -16,17 +16,13 @@ trait CustomClaims
 {
     /**
      * Custom claims.
-     *
-     * @var array
      */
-    protected $customClaims = [];
+    protected array $customClaims = [];
 
     /**
      * Set the custom claims.
-     *
-     * @return $this
      */
-    public function customClaims(array $customClaims)
+    public function setCustomClaims(array $customClaims): self
     {
         $this->customClaims = $customClaims;
 
@@ -34,22 +30,28 @@ trait CustomClaims
     }
 
     /**
-     * Alias to set the custom claims.
-     *
-     * @return $this
+     * Get the custom claims.
      */
-    public function claims(array $customClaims)
+    public function getCustomClaims(): array
     {
-        return $this->customClaims($customClaims);
+        return $this->customClaims;
     }
 
     /**
-     * Get the custom claims.
-     *
-     * @return array
+     * Alias of setCustomClaims.
+     * @deprecated Please use setCustomClaims(array)
      */
-    public function getCustomClaims()
+    public function customClaims(array $customClaims): self
     {
-        return $this->customClaims;
+        return $this->setCustomClaims($customClaims);
+    }
+
+    /**
+     * Alias of setCustomClaims.
+     * @deprecated Please use setCustomClaims(array)
+     */
+    public function claims(array $customClaims): self
+    {
+        return $this->setCustomClaims($customClaims);
     }
 }

--- a/src/Support/CustomClaims.php
+++ b/src/Support/CustomClaims.php
@@ -22,7 +22,7 @@ trait CustomClaims
     /**
      * Set the custom claims.
      */
-    public function setCustomClaims(array $customClaims): self
+    public function setCustomClaims(array $customClaims): static
     {
         $this->customClaims = $customClaims;
 
@@ -41,7 +41,7 @@ trait CustomClaims
      * Alias of setCustomClaims.
      * @deprecated Please use setCustomClaims(array)
      */
-    public function customClaims(array $customClaims): self
+    public function customClaims(array $customClaims): static
     {
         return $this->setCustomClaims($customClaims);
     }
@@ -50,7 +50,7 @@ trait CustomClaims
      * Alias of setCustomClaims.
      * @deprecated Please use setCustomClaims(array)
      */
-    public function claims(array $customClaims): self
+    public function claims(array $customClaims): static
     {
         return $this->setCustomClaims($customClaims);
     }

--- a/src/Support/RefreshFlow.php
+++ b/src/Support/RefreshFlow.php
@@ -16,19 +16,13 @@ trait RefreshFlow
 {
     /**
      * The refresh flow flag.
-     *
-     * @var bool
      */
-    protected $refreshFlow = false;
+    protected bool $refreshFlow = false;
 
     /**
      * Set the refresh flow flag.
-     *
-     * @param bool $refreshFlow
-     *
-     * @return $this
      */
-    public function setRefreshFlow($refreshFlow = true)
+    public function setRefreshFlow(bool $refreshFlow = true): static
     {
         $this->refreshFlow = $refreshFlow;
 

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -17,36 +17,25 @@ use Carbon\Carbon;
 class Utils
 {
     /**
-     * Get the Carbon instance for the current time.
-     *
-     * @return Carbon
+     * Get the Carbon instance for the current time, in the UTC timezone
      */
-    public static function now()
+    public static function now(): Carbon
     {
         return Carbon::now('UTC');
     }
 
     /**
-     * Get the Carbon instance for the timestamp.
-     *
-     * @param int $timestamp
-     *
-     * @return Carbon
+     * Get the Carbon instance for a unix timestamp, in UTC
      */
-    public static function timestamp($timestamp)
+    public static function timestamp(int $timestamp): Carbon
     {
         return Carbon::createFromTimestampUTC($timestamp)->timezone('UTC');
     }
 
     /**
-     * Checks if a timestamp is in the past.
-     *
-     * @param int $timestamp
-     * @param int $leeway
-     *
-     * @return bool
+     * Checks if a unix timestamp is in the past.
      */
-    public static function isPast($timestamp, $leeway = 0)
+    public static function isPast(int $timestamp, int $leeway = 0): bool
     {
         $timestamp = static::timestamp($timestamp);
 
@@ -56,14 +45,9 @@ class Utils
     }
 
     /**
-     * Checks if a timestamp is in the future.
-     *
-     * @param int $timestamp
-     * @param int $leeway
-     *
-     * @return bool
+     * Checks if a unix timestamp is in the future.
      */
-    public static function isFuture($timestamp, $leeway = 0)
+    public static function isFuture(int $timestamp, int $leeway = 0): bool
     {
         $timestamp = static::timestamp($timestamp);
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -21,33 +21,25 @@ class Token
     /**
      * Create a new JSON Web Token.
      *
-     * @param string $value
-     *
-     * @return void
-     *
      * @throws Exceptions\TokenInvalidException
      */
-    public function __construct($value)
+    public function __construct(string $value)
     {
-        $this->value = (string) (new TokenValidator())->check($value);
+        $this->value = (new TokenValidator())->check($value);
     }
 
     /**
-     * Get the token.
-     *
-     * @return string
+     * Get the token as string.
      */
-    public function get()
+    public function get(): string
     {
         return $this->value;
     }
 
     /**
      * Get the token when casting to string.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->get();
     }


### PR DESCRIPTION
This is an early draft at this stage.

The aim is to address some recent challenges with the typing of some config ints in a backwards-compatible way, while also adding typing in various places where reasonable.

### Discussion Points
 - Since this will involve change of the public API of the package (contracts and things), I think a major version may be a in order? It's entirely possible that someone using this package will have a broken install after this update.
 - Do we want to continue to support Lumen? Laravel themselves have moved away from it, and it hasn't had a major version since v10 (ie. side by side with Laravel 10). This may be a good opportunity to drop support for it, if we do bump major version.

### Changes Beyond types
 - Custom Claims
Renamed the function "customClaims" to "getCustomClaims" to be in line with "setCustomClaims". I kept the current one, just marked as deprecated.