### PR TITLE
gha: switch to latest ubuntu runner

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -10,7 +10,7 @@ jobs:
   php-cs-fixer:
     name: Fix Code Style
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       COMPOSER_NO_INTERACTION: 1
 


### PR DESCRIPTION
## Description
ubuntu-20.04 is being retired, see https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
