### PR TITLE
Update lcobucci/jwt library to support php 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/contracts": "^10|^11|^12",
         "illuminate/http": "^10|^11|^12",
         "illuminate/support": "^10|^11|^12",
-        "lcobucci/jwt": "^5.0",
+        "lcobucci/jwt": "^5.4",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^2.0|^3.0"
     },


### PR DESCRIPTION
Update dependancy [lcobucci](https://github.com/lcobucci)
[jwt](https://github.com/lcobucci/jwt) from 5.0 to 5.4 to support PHP 8.4

## Description
Since there is no relevant changes in release 5.4 [PR](https://github.com/lcobucci/jwt/pull/1071)

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
