### PR TITLE
Fixed the return type of getMinutesUntilExpired in BlackList, which returned a float instead of an int when using Carbon v2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/PHP-Open-Source-Saver/jwt-auth/releases).
 
 ## [Unreleased]
+### Fixed
+ - Fixed the return type of getMinutesUntilExpired in BlackList, which returned a float instead of an int when using Carbon v2.
 
 ## [2.8.0] 2025-02-11
 Please see (https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.8.0)

--- a/src/Blacklist.php
+++ b/src/Blacklist.php
@@ -99,7 +99,7 @@ class Blacklist
 
         // Handle Carbon 2 vs 3 deprecation of "Real" diff functions, see https://github.com/PHP-Open-Source-Saver/jwt-auth/issues/260
         if (method_exists($intermediateResult, 'diffInRealMinutes')) {
-            return round($intermediateResult->diffInRealMinutes(null, true));
+            return (int) round($intermediateResult->diffInRealMinutes(null, true));
         } else {
             return (int) round($intermediateResult->diffInMinutes(null, true));
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Fixed the return type of getMinutesUntilExpired in BlackList, which returned a float instead of an int when using Carbon v2.

## Checklist:

- [✖] I've added tests for my changes or tests are not applicable
- [✔] I've changed documentations or changes are not required
- [ ✔] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
