### PR TITLE
Fix PHPStan Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ You can find and compare releases at the [GitHub release page](https://github.co
 ## [Unreleased]
 ### Fixed
  - Fixed the return type of getMinutesUntilExpired in BlackList, which returned a float instead of an int when using Carbon v2.
+ - Fixed PHPStan issue in JWTGenerateSecretCommand by ensuring displayKey($key); is called before returning, avoiding returning a void method.  
+ - Fixed missing return true; statements in validatePayload() and validateRefresh() methods of Expiration.php, IssuedAt.php, and NotBefore.php to resolve PHPStan errors.  
+ - Fixed PHPStan error related to new static() by making the constructor final in Collection.php.  
+
 
 ## [2.8.0] 2025-02-11
 Please see (https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.8.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can find and compare releases at the [GitHub release page](https://github.co
  - Fixed the return type of getMinutesUntilExpired in BlackList, which returned a float instead of an int when using Carbon v2.
  - Fixed PHPStan issue in JWTGenerateSecretCommand by ensuring displayKey($key); is called before returning, avoiding returning a void method.  
  - Fixed missing return true; statements in validatePayload() and validateRefresh() methods of Expiration.php, IssuedAt.php, and NotBefore.php to resolve PHPStan errors.  
- - Fixed PHPStan error related to new static() by making the constructor final in Collection.php.  
+ - Fixed PHPStan error related to new static() by refactoring hasAllClaims method in Collection class.
 
 
 ## [2.8.0] 2025-02-11

--- a/log
+++ b/log
@@ -1,6 +1,0 @@
-chore: update CHANGELOG with recent PHPStan fixes
-
-Added entries to the CHANGELOG for fixes addressing PHPStan issues:
-- Ensured displayKey($key); is called before returning in JWTGenerateSecretCommand.
-- Added missing return true; statements in Expiration.php, IssuedAt.php, and NotBefore.php.
-- Made the constructor final in Collection.php to fix new static() usage.

--- a/log
+++ b/log
@@ -1,0 +1,6 @@
+chore: update CHANGELOG with recent PHPStan fixes
+
+Added entries to the CHANGELOG for fixes addressing PHPStan issues:
+- Ensured displayKey($key); is called before returning in JWTGenerateSecretCommand.
+- Added missing return true; statements in Expiration.php, IssuedAt.php, and NotBefore.php.
+- Made the constructor final in Collection.php to fix new static() usage.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Result of method PHPOpenSourceSaver\\\\JWTAuth\\\\Console\\\\JWTGenerateSecretCommand\\:\\:displayKey\\(\\) \\(void\\) is used\\.$#"
-			count: 1
-			path: src/Console/JWTGenerateSecretCommand.php
-
-		-
 			message: "#^Class Laravel\\\\Octane\\\\Events\\\\RequestReceived not found\\.$#"
 			count: 1
 			path: src/Providers/LaravelServiceProvider.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,26 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\Expiration\\:\\:validatePayload\\(\\) should return bool but return statement is missing\\.$#"
-			count: 1
-			path: src/Claims/Expiration.php
-
-		-
-			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\IssuedAt\\:\\:validatePayload\\(\\) should return bool but return statement is missing\\.$#"
-			count: 1
-			path: src/Claims/IssuedAt.php
-
-		-
-			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\IssuedAt\\:\\:validateRefresh\\(\\) should return bool but return statement is missing\\.$#"
-			count: 1
-			path: src/Claims/IssuedAt.php
-
-		-
-			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\NotBefore\\:\\:validatePayload\\(\\) should return bool but return statement is missing\\.$#"
-			count: 1
-			path: src/Claims/NotBefore.php
-
-		-
 			message: "#^Result of method PHPOpenSourceSaver\\\\JWTAuth\\\\Console\\\\JWTGenerateSecretCommand\\:\\:displayKey\\(\\) \\(void\\) is used\\.$#"
 			count: 1
 			path: src/Console/JWTGenerateSecretCommand.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Claims/Collection.php
-
-		-
 			message: "#^Method PHPOpenSourceSaver\\\\JWTAuth\\\\Claims\\\\Expiration\\:\\:validatePayload\\(\\) should return bool but return statement is missing\\.$#"
 			count: 1
 			path: src/Claims/Expiration.php

--- a/src/Claims/Collection.php
+++ b/src/Claims/Collection.php
@@ -22,7 +22,7 @@ class Collection extends IlluminateCollection
      *
      * @return void
      */
-    final public function __construct($items = [])
+    public function __construct($items = [])
     {
         parent::__construct($this->getArrayableItems($items));
     }
@@ -70,7 +70,17 @@ class Collection extends IlluminateCollection
      */
     public function hasAllClaims($claims)
     {
-        return count($claims) && (new static($claims))->diff($this->keys())->isEmpty();
+        if (!count($claims)) {
+            return false;
+        }
+
+        foreach ($claims as $claim) {
+            if (!$this->has($claim)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Claims/Collection.php
+++ b/src/Claims/Collection.php
@@ -22,7 +22,7 @@ class Collection extends IlluminateCollection
      *
      * @return void
      */
-    public function __construct($items = [])
+    final public function __construct($items = [])
     {
         parent::__construct($this->getArrayableItems($items));
     }

--- a/src/Claims/Expiration.php
+++ b/src/Claims/Expiration.php
@@ -25,5 +25,7 @@ class Expiration extends Claim
         if ($this->isPast($this->getValue())) {
             throw new TokenExpiredException('Token has expired');
         }
+
+        return true;
     }
 }

--- a/src/Claims/IssuedAt.php
+++ b/src/Claims/IssuedAt.php
@@ -40,6 +40,8 @@ class IssuedAt extends Claim
         if ($this->isFuture($this->getValue())) {
             throw new TokenInvalidException('Issued At (iat) timestamp cannot be in the future');
         }
+
+        return true;
     }
 
     public function validateRefresh($refreshTTL)
@@ -47,5 +49,7 @@ class IssuedAt extends Claim
         if ($this->isPast($this->getValue() + $refreshTTL * 60)) {
             throw new TokenExpiredException('Token has expired and can no longer be refreshed');
         }
+
+        return true;
     }
 }

--- a/src/Claims/NotBefore.php
+++ b/src/Claims/NotBefore.php
@@ -28,5 +28,7 @@ class NotBefore extends Claim
         if ($this->isFuture($this->getValue())) {
             throw new TokenInvalidException('Not Before (nbf) timestamp cannot be in the future');
         }
+
+        return true;
     }
 }

--- a/src/Console/JWTGenerateSecretCommand.php
+++ b/src/Console/JWTGenerateSecretCommand.php
@@ -52,7 +52,9 @@ class JWTGenerateSecretCommand extends Command
         }
 
         if (!$this->envFileExists()) {
-            return $this->displayKey($key);
+            $this->displayKey($key);
+
+            return;
         }
 
         $updated = $this->updateEnvEntry('JWT_SECRET', $key, function () {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

This update resolves multiple PHPStan issues:
- Fixed an issue in `JWTGenerateSecretCommand` by ensuring `displayKey($key);` is called before returning, avoiding returning a void method.
- Added missing `return true;` statements in `Expiration.php`, `IssuedAt.php`, and `NotBefore.php` to comply with PHPStan expectations.
- Refactor `hasAllClaims` method to avoid unsafe usage of `new static()`.
- Updated `CHANGELOG.md` to reflect these fixes.

<!-- Fixes # (issue) -->

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
