### PR TITLE
Updating composer and CI for Laravel 13

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: 
+github: [specialtactics]
+patreon:
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           coverage: none
 
       - name: Determine composer cache directory

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           coverage: none
 
       - name: Get composer cache directory

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,17 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         coverage: [none]
         include:
           - php: 8.3
-            laravel: 11.*
+            laravel: 13.*
             stability: prefer-stable
             coverage: xdebug
-          - php: 8.3
-            laravel: 11.*
-            carbon: 3.*
 
     name: 'P${{ matrix.php }} L${{ matrix.laravel }} ${{ matrix.stability }} c:${{ matrix.coverage }}'
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         coverage: [none]
         include:

--- a/composer.json
+++ b/composer.json
@@ -40,20 +40,20 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "illuminate/auth": "^10|^11|^12|^13",
-        "illuminate/contracts": "^10|^11|^12|^13",
-        "illuminate/http": "^10|^11|^12|^13",
-        "illuminate/support": "^10|^11|^12|^13",
+        "illuminate/auth": "^12|^13",
+        "illuminate/contracts": "^12|^13",
+        "illuminate/http": "^12|^13",
+        "illuminate/support": "^12|^13",
         "lcobucci/jwt": "^5.4",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^2.0|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
-        "illuminate/console": "^10|^11|^12|^13",
-        "illuminate/routing": "^10|^11|^12|^13",
-        "orchestra/testbench": "^8|^9|^10|^11",
+        "illuminate/console": "^12|^13",
+        "illuminate/routing": "^12|^13",
         "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^10|^11",
         "phpstan/phpstan": "^2",
         "phpunit/phpunit": "^10.5|^11"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,21 +38,21 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-json": "*",
-        "illuminate/auth": "^10|^11|^12",
-        "illuminate/contracts": "^10|^11|^12",
-        "illuminate/http": "^10|^11|^12",
-        "illuminate/support": "^10|^11|^12",
+        "illuminate/auth": "^10|^11|^12|^13",
+        "illuminate/contracts": "^10|^11|^12|^13",
+        "illuminate/http": "^10|^11|^12|^13",
+        "illuminate/support": "^10|^11|^12|^13",
         "lcobucci/jwt": "^5.4",
         "namshi/jose": "^7.0",
         "nesbot/carbon": "^2.0|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
-        "illuminate/console": "^10|^11|^12",
-        "illuminate/routing": "^10|^11|^12",
-        "orchestra/testbench": "^8|^9|^10",
+        "illuminate/console": "^10|^11|^12|^13",
+        "illuminate/routing": "^10|^11|^12|^13",
+        "orchestra/testbench": "^8|^9|^10|^11",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^2",
         "phpunit/phpunit": "^10.5|^11"
@@ -68,9 +68,6 @@
         }
     },
     "extra": {
-        "branch-alias": {
-            "dev-develop": "2.0-dev"
-        },
         "laravel": {
             "aliases": {
                 "JWTAuth": "PHPOpenSourceSaver\\JWTAuth\\Facades\\JWTAuth",


### PR DESCRIPTION
## Description
 - Updated composer for Laravel 13
 - Updated CI for PHP 8.5 and Laravel 13
 - Bumped minimum PHP to 8.3 from 8.2
 - Removed older Laravel versions 10 and 11 as they are no longer maintained