### PR TITLE
feat: Trigger Authenticated event when loading user from token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find and compare releases at the [GitHub release page](https://github.com/PHP-Open-Source-Saver/jwt-auth/releases).
 
 ## [Unreleased]
-### Fixed
- - Fixed the return type of getMinutesUntilExpired in BlackList, which returned a float instead of an int when using Carbon v2.
- - Fixed PHPStan issue in JWTGenerateSecretCommand by ensuring displayKey($key); is called before returning, avoiding returning a void method.  
- - Fixed missing return true; statements in validatePayload() and validateRefresh() methods of Expiration.php, IssuedAt.php, and NotBefore.php to resolve PHPStan errors.  
- - Fixed PHPStan error related to new static() by refactoring hasAllClaims method in Collection class.
 
+### Added
+- Trigger Authenticated event when loading user from token
+
+## [2.9.0] 2026-03-06
+Please see (https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.9.0)
+
+### Added
+- Updating composer and CI for Laravel 13
+
+## [2.8.3] 2025-10-15
+Please see (https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.8.3)
+
+### Fixed
+- Implement config variable to allow iat to remain unchanged claim when refreshing a token
+
+## [2.8.2] 2025-03-19
+Please see (https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.8.2)
+
+### Fixed
+- Fix PHPStan Issues  
+
+## [2.8.1] 2025-02-28
+Please see (https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.8.1)
+
+### Fixed
+- Fixed the return type of getMinutesUntilExpired in BlackList, which returned a float instead of an int when using Carbon v2.
 
 ## [2.8.0] 2025-02-11
 Please see (https://github.com/PHP-Open-Source-Saver/jwt-auth/releases/tag/2.8.0)

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -104,7 +104,9 @@ class JWTGuard implements Guard
             && ($payload = $this->jwt->check(true))
             && $this->validateSubject()
         ) {
-            return $this->user = $this->provider->retrieveById($payload['sub']);
+            $this->setUser($this->provider->retrieveById($payload['sub']));
+
+            return $this->user;
         }
     }
 

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -79,16 +79,20 @@ class JWTGuardTest extends AbstractTestCase
         $this->provider->shouldReceive('retrieveById')
             ->once()
             ->with(1)
-            ->andReturn((object) ['id' => 1]);
+            ->andReturn(new LaravelUserStub());
 
-        $this->assertSame(1, $this->guard->user()->id);
+        $this->eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(\Mockery::type(Authenticated::class));
+
+        $this->assertSame(1, $this->guard->user()->getAuthIdentifier());
 
         // check that the user is stored on the object next time round
-        $this->assertSame(1, $this->guard->user()->id);
+        $this->assertSame(1, $this->guard->user()->getAuthIdentifier());
         $this->assertTrue($this->guard->check());
 
         // also make sure userOrFail does not fail
-        $this->assertSame(1, $this->guard->userOrFail()->id);
+        $this->assertSame(1, $this->guard->userOrFail()->getAuthIdentifier());
     }
 
     public function testItShouldGetTheAuthenticatedUserIfAValidTokenIsProvidedAndNotThrowAnException()
@@ -110,12 +114,16 @@ class JWTGuardTest extends AbstractTestCase
         $this->provider->shouldReceive('retrieveById')
             ->once()
             ->with(1)
-            ->andReturn((object) ['id' => 1]);
+            ->andReturn(new LaravelUserStub());
 
-        $this->assertSame(1, $this->guard->userOrFail()->id);
+        $this->eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(\Mockery::type(Authenticated::class));
+
+        $this->assertSame(1, $this->guard->userOrFail()->getAuthIdentifier());
 
         // check that the user is stored on the object next time round
-        $this->assertSame(1, $this->guard->userOrFail()->id);
+        $this->assertSame(1, $this->guard->userOrFail()->getAuthIdentifier());
         $this->assertTrue($this->guard->check());
     }
 


### PR DESCRIPTION
The default Laravel session guard triggers the Authenticated event when a user is loaded from the session, this PR aims to make the JWTGuard consistent with that behaviour.

## Description

Trigger the Authenticated event when loading a user from a token instead of only doing so when explicitly logging a token in. The Laravel Session guard also has this behaviour, and this creates a consistent event to listen to, to see which user is currently active. For example when implementing Sentry for logging this is the recommended event to listen to when registering a user scope.

## Checklist:

- [x] I've added tests for my changes or tests are not applicable
- [x] I've changed documentations or changes are not required
- [x] I've added my changes to [`CHANGELOG.md`](/CHANGELOG.md)
